### PR TITLE
Fix small typo in test comment

### DIFF
--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -59,7 +59,7 @@ df[, 'y'] <- as.factor(df[, 'y'])
 
 ######################
 context("episcout_plots")
-# ALl episcout reference plots will/should be saved in
+# All episcout reference plots will/should be saved in
 # XXXX/episcout/tests/figs/episcout_plots
 print("episcout plot function tests")
 print("Function being tested: epi_plot_list")


### PR DESCRIPTION
## Summary
- fix a typo in `test-plotting.R`

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422250ad288326aa847008b71f8ad8