### PR TITLE
Fix allowAll handling in compare call

### DIFF
--- a/R/epi_clean_compare_dup_rows.R
+++ b/R/epi_clean_compare_dup_rows.R
@@ -64,7 +64,7 @@ epi_clean_compare_dup_rows <- function(df_dups = NULL,
   # check_dups[dup_indices, 1:2]
   comp <- compare::compare(df_dups[dup_indices[sub_index_1], , drop = FALSE],
                            df_dups[dup_indices[sub_index_2], , drop = FALSE],
-                           allowAll = TRUE,
+                           allowAll = allowAll,
                            ...
                            )
   comp_diff <- which(comp$detailedResult == FALSE)


### PR DESCRIPTION
## Summary
- use the function argument in `compare::compare` instead of a constant

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68422295066c832693ef57825b052421