### PR TITLE
Modify cleaning test

### DIFF
--- a/tests/testthat/test-cleaning_functions.R
+++ b/tests/testthat/test-cleaning_functions.R
@@ -111,8 +111,8 @@ test_that("Test expected output after epi_clean_cond_numeric", {
   expect_output(str(head(get_cols, 1)), 'x     : num 0.586')
   expect_output(str(tail(get_cols, 1)), 'z     : int 1')
   expect_output(str(tail(get_cols, 1)), 'var_id: int 10')
-  expect_output(str(epi_clean_cond_numeric(df[[2]])), 'FALSE')
-  expect_output(str(epi_clean_cond_numeric(df[, 'x'])), 'TRUE')
+  expect_false(epi_clean_cond_numeric(df[[2]]))
+  expect_true(epi_clean_cond_numeric(df[, 'x']))
   }
   )
 ######################


### PR DESCRIPTION
## Summary
- update epi_clean_cond_numeric expectations with logical variants

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: could not find functions)*

------
https://chatgpt.com/codex/tasks/task_e_684222bd84288326a24005aa544921fe