### PR TITLE
Fix README duplicate function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ epi_head_and_tail(df, rows = 2, cols = 2, last_cols = TRUE)
 
 
 # Get all duplicates:
-check_dups <- epi_clean_get_dups.R(df, 'var_id', 1)
+check_dups <- epi_clean_get_dups(df, 'var_id', 1)
 dim(check_dups)
 check_dups
 


### PR DESCRIPTION
## Summary
- fix README example calling `epi_clean_get_dups.R()`

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684222a68f748326af078e7fe7ffe44d