### PR TITLE
Fix R build by removing openxlsx dependency

### DIFF
--- a/R/grob_files_to_excel.R
+++ b/R/grob_files_to_excel.R
@@ -1,6 +1,5 @@
-############
-library(openxlsx)
 
+############
 ###
 # Functions
 


### PR DESCRIPTION
## Summary
- drop the unconditional `library(openxlsx)` call that caused package build failures on macOS

## Testing
- `Rscript -e 'devtools::test()'` *(fails: `Rscript` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430b10d26c8326ada0e4a0647fdd0c