### PR TITLE
Fix duplicate row compare exact match

### DIFF
--- a/R/epi_clean_compare_dup_rows.R
+++ b/R/epi_clean_compare_dup_rows.R
@@ -57,10 +57,7 @@ epi_clean_compare_dup_rows <- function(df_dups = NULL,
          call. = FALSE)
   }
   val_id <- as.character(val_id)
-  dup_indices <- which(grepl(val_id,
-                             df_dups[[col_id]],
-                             fixed = TRUE) # match as string, not regex
-  )
+  dup_indices <- which(as.character(df_dups[[col_id]]) == val_id)
   # check_dups[dup_indices, 1:2]
   comp <- compare::compare(df_dups[dup_indices[sub_index_1], , drop = FALSE],
                            df_dups[dup_indices[sub_index_2], , drop = FALSE],

--- a/tests/testthat/test-cleaning_functions.R
+++ b/tests/testthat/test-cleaning_functions.R
@@ -63,14 +63,14 @@ print("Function being tested: epi_clean_compare_dup_rows")
 test_that("Test expected output after epi_clean_compare_dup_rows", {
   # Check a few duplicated individuals:
   check_dups <- epi_clean_get_dups(df, 'var_id', 1)
-  val_id <- '2' # TO DO: '1' matches '1' and '10' despite fixed = TRUE
+  val_id <- '1'
   comp <- epi_clean_compare_dup_rows(check_dups, val_id, 'var_id', 1, 2)
   # comp
   # View(t(check_dups[comp$duplicate_indices, ]))
   # View(t(check_dups[comp$duplicate_indices, comp$differing_cols]))
   expect_output(str(comp$differing_cols), ' 3 5')
   expect_output(str(comp$col_names), ' "x" "z"')
-  expect_output(str(comp$duplicate_indices), ' 3 4')
+  expect_output(str(comp$duplicate_indices), ' 1 2')
   }
   )
 ######################


### PR DESCRIPTION
## Summary
- avoid substring matching when finding duplicates
- adjust unit test to verify exact matching for `val_id` == '1'

## Testing
- `devtools::test()` *(fails: "str(head(df2))" mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68430b9b15748326ae586e0ae4ced423