### PR TITLE
Fix issue #1 in merge function

### DIFF
--- a/R/epi_clean_merge_nested_dfs.R
+++ b/R/epi_clean_merge_nested_dfs.R
@@ -3,6 +3,7 @@
 #' @description Recursively merge data frames that are stored as lists within a list.
 #' Flattens with purrr::flatten() if there is more than one level. Assumes:
 #' - there are are 3 or more data frames to merge
+#'   (if only two are supplied the function performs a single merge and returns)
 #' - there are no duplicates in any of the data frames
 #' The function performs a full outer join with base R
 #' merge(df1, df2, by = id_col, all = TRUE)
@@ -136,6 +137,10 @@ epi_clean_merge_nested_dfs <- function(nested_list_dfs = NULL,
     stop("Package data.table needed for this function to work. Please install it.",
          call. = FALSE)
   }
+  # Check there are at least two data frames
+  if (length(nested_list_dfs) < 2) {
+    stop('nested_list_dfs must contain at least two data frames')
+  }
   # Initialise merge:
   df1 <- data.table::as.data.table(nested_list_dfs[[1]])
   df2 <- data.table::as.data.table(nested_list_dfs[[2]])
@@ -167,6 +172,10 @@ epi_clean_merge_nested_dfs <- function(nested_list_dfs = NULL,
                    suffixes = c(suffix_1, suffix_2),
                    ...
                    )
+  if (length(nested_list_dfs) == 2) {
+    print('Only two data frames provided, returning result of single merge.')
+    return(temp_df)
+  }
   # Loop through nested data frames and merge each to previous merged df:
   # TO DO: if there were truly many and large DFs could add a parallel option
   print('Merging further dataframes.')

--- a/man/epi_clean_merge_nested_dfs.Rd
+++ b/man/epi_clean_merge_nested_dfs.Rd
@@ -33,6 +33,7 @@ Recursively merge data frames that are stored as lists within a list.
 Flattens with purrr::flatten() if there is more than one level. Assumes:
 \itemize{
 \item there are are 3 or more data frames to merge
+\item if only two data frames are supplied the function performs a single merge and returns
 \item there are no duplicates in any of the data frames
 The function performs a full outer join with base R
 merge(df1, df2, by = id_col, all = TRUE)

--- a/tests/testthat/test-cleaning_functions.R
+++ b/tests/testthat/test-cleaning_functions.R
@@ -304,6 +304,17 @@ test_that("epi_clean_merge_nested_dfs", {
   expect_output(str(all_merged), '1 3 1 1 4 2 1 2 2 1') # z.Post_6
   }
   )
+
+test_that("epi_clean_merge_nested_dfs handles two dfs", {
+  df_spread <- epi_clean_spread_repeated(df, 'var_to_rep', 1)
+  nested_two <- list(df_spread[[1]], df_spread[[2]])
+  id_col <- 'var_id'
+  expect_output(
+    res <- epi_clean_merge_nested_dfs(nested_two, id_col),
+    'Only two data frames provided'
+  )
+  expect_true(is.data.frame(res))
+})
 ######################
 
 


### PR DESCRIPTION
## Summary
- handle case when only two data frames are provided to `epi_clean_merge_nested_dfs`
- update documentation for the new behaviour
- add unit test for two data frame merge

## Testing
- `R -q -e "devtools::test()"` *(fails: `expect_output` mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6843115486108326b6412285bee8bedb