### PR TITLE
Fix missing tibble library in examples

### DIFF
--- a/R/epi_clean_add_rep_num.R
+++ b/R/epi_clean_add_rep_num.R
@@ -27,6 +27,7 @@
 #' @examples
 #'
 #' \dontrun{
+#' library(tibble)
 #' n <- 20
 #' df <- data.frame(
 #' var_id = rep(1:(n / 2), each = 2),

--- a/R/epi_clean_cond_chr_fct.R
+++ b/R/epi_clean_cond_chr_fct.R
@@ -23,6 +23,7 @@
 #'
 #' \dontrun{
 #' library(dplyr)
+#' library(tibble)
 #' col_chr <- data.frame('chr1' = rep(c('A', 'B')),
 #'                       'chr2' = rep(c('C', 'D'))
 #'              )

--- a/man/epi_clean_add_rep_num.Rd
+++ b/man/epi_clean_add_rep_num.Rd
@@ -35,6 +35,7 @@ measurement rows for example
 \examples{
 
 \dontrun{
+library(tibble)
 n <- 20
 df <- data.frame(
 var_id = rep(1:(n / 2), each = 2),

--- a/man/epi_clean_cond_chr_fct.Rd
+++ b/man/epi_clean_cond_chr_fct.Rd
@@ -23,6 +23,7 @@ extracting columns from a large data frame using dplyr
 
 \dontrun{
 library(dplyr)
+library(tibble)
 col_chr <- data.frame('chr1' = rep(c('A', 'B')),
                       'chr2' = rep(c('C', 'D'))
              )


### PR DESCRIPTION
## Summary
- add `library(tibble)` in roxygen examples
- update manual pages accordingly

## Testing
- `Rscript` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_684316d150a48326adc08e10a3f0d61e