### PR TITLE
Add missing tests for logging utilities

### DIFF
--- a/tests/testthat/test-utility.R
+++ b/tests/testthat/test-utility.R
@@ -68,3 +68,35 @@ test_that("epi_utils_multicore multi", {
   }
   )
 ######################
+
+print("Function being tested: epi_utils_log")
+
+test_that("epi_utils_log writes log to file", {
+  tmp_prefix <- tempfile("log_file")
+  out <- capture.output(epi_utils_log(tmp_prefix))
+  log_file <- paste0(tmp_prefix, "_log.txt")
+  expect_true(any(grepl("Session information saved in", out)))
+  expect_true(file.exists(log_file))
+  first_line <- readLines(log_file, n = 1)
+  expect_true(grepl("R version", first_line))
+  unlink(log_file)
+})
+
+print("Function being tested: epi_utils_session")
+
+test_that("epi_utils_session saves selected objects", {
+  tmp_prefix <- tempfile("session_file")
+  a <- 1:3
+  b <- "test"
+  out <- capture.output(epi_utils_session(tmp_prefix, objects_to_save = c("a", "b")))
+  session_file <- paste0(tmp_prefix, ".RData")
+  expect_true(any(grepl("Saved objects as", out)))
+  expect_true(file.exists(session_file))
+  new_env <- new.env()
+  load(session_file, envir = new_env)
+  expect_identical(new_env$a, a)
+  expect_identical(new_env$b, b)
+  unlink(session_file)
+})
+
+######################


### PR DESCRIPTION
## Summary
- test `epi_utils_log` to ensure log file is created
- test `epi_utils_session` to ensure session objects are saved

## Testing
- `R -q -e "devtools::test()"` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68432e6e4a688326b62ee251724cc4e1