### PR TITLE
Fix contingency example file handling

### DIFF
--- a/R/epi_stats_contingency_2x2.R
+++ b/R/epi_stats_contingency_2x2.R
@@ -70,6 +70,7 @@
 #' # Save results
 #' tmp <- tempfile("fishers_results", fileext = ".txt")
 #' write.table(results_df, tmp, sep = "\t", row.names = FALSE, quote = FALSE)
+#' unlink(tmp)
 #'
 #' @importFrom tidyr pivot_wider
 #' @importFrom stats xtabs

--- a/man/combined_contingency_2x2_functions.Rd
+++ b/man/combined_contingency_2x2_functions.Rd
@@ -111,5 +111,6 @@ print(results_df)
 # Save results
 tmp <- tempfile("fishers_results", fileext = ".txt")
 write.table(results_df, tmp, sep = "\t", row.names = FALSE, quote = FALSE)
+unlink(tmp)
 
 }


### PR DESCRIPTION
## Summary
- write example output for fishers_results to a tempfile
- delete the temporary results file

## Testing
- `R CMD build . --no-build-vignettes --no-manual`
- `R CMD check episcout_0.1.2.tar.gz --no-manual --ignore-vignettes` *(fails: Packages required but not available)*

------
https://chatgpt.com/codex/tasks/task_e_684353a2be248326a481c6307f83c514