### PR TITLE
Fix CURP example with explicit purrr call

### DIFF
--- a/R/epi_clean_curp.R
+++ b/R/epi_clean_curp.R
@@ -28,7 +28,7 @@
 #' )
 #'
 #' # Aplicar la funcion a un vector de CURPs
-#' resultados <- purrr::map_dfr(curps, epi_clean_curp)
+#' resultados <- purrr::map_dfr(.x = curps, .f = epi_clean_curp)
 #'
 #' # Mostrar resultados
 #' print(t(resultados))

--- a/man/epi_clean_curp.Rd
+++ b/man/epi_clean_curp.Rd
@@ -41,7 +41,7 @@ curps <- c(
 )
 
 # Aplicar la funcion a un vector de CURPs
-resultados <- purrr::map_dfr(curps, epi_clean_curp)
+resultados <- purrr::map_dfr(.x = curps, .f = epi_clean_curp)
 
 # Mostrar resultados
 print(t(resultados))


### PR DESCRIPTION
## Summary
- use a fully qualified purrr example in `epi_clean_curp`
- update matching Rd documentation

## Testing
- `devtools::document()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843538c2f3c8326bf540dbe1e62aae7