### PR TITLE
Fix docs for contingency list parameter

### DIFF
--- a/man/combined_contingency_2x2_functions.Rd
+++ b/man/combined_contingency_2x2_functions.Rd
@@ -41,8 +41,7 @@ epi_stats_contingency_2x2_all(df, target_var, test_type = "fisher.test")
 \item{test_type}{The type of test to perform. Either \code{"fisher.test"} (default) or \code{"chisq.test"}.}
 
 \item{min_unique}{Minimum number of unique values required to include a column for testing (default: 2).}
-\item{contingency_2x2_list}{A list of contingency tables created by
-\code{epi_stats_contingency_2x2_tables()}.}
+\item{contingency_2x2_list}{A list of contingency tables created by \code{epi_stats_contingency_2x2_tables()}.}
 }
 \value{
 \itemize{


### PR DESCRIPTION
## Summary
- document `contingency_2x2_list` argument in `combined_contingency_2x2_functions.Rd`

## Testing
- `tools::checkRd('man/combined_contingency_2x2_functions.Rd')`
- `R CMD check episcout_0.1.2.tar.gz` *(fails: packages required but not available)*

------
https://chatgpt.com/codex/tasks/task_e_684353859cc483268cffdf207a4deeda