### PR TITLE
Fix epi_stats_dates doc

### DIFF
--- a/man/epi_stats_dates.Rd
+++ b/man/epi_stats_dates.Rd
@@ -174,7 +174,6 @@ stat_sum_zero
 \code{\link{epi_stats_format}},
 \code{\link{epi_stats_numeric}}.
 
-TO DO:
 }
 \author{
 Antonio J Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}


### PR DESCRIPTION
## Summary
- remove outdated placeholder from `epi_stats_dates` documentation

## Testing
- `R CMD build .`

------
https://chatgpt.com/codex/tasks/task_e_68435393ef8c8326b0aa22e2a9b2a71c