### PR TITLE
Use r2u for faster GH actions

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 360
     strategy:
       matrix:
         # run on popular OSes including Windows, "windows-latest"
@@ -32,6 +33,10 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r-version }}
+
+      - name: Setup r2u
+        if: runner.os == 'Linux'
+        uses: eddelbuettel/github-actions/r2u-setup@master
 
       # 2.1) Cache installs:
       - name: Cache R packages


### PR DESCRIPTION
## Summary
- add `timeout-minutes` to avoid cancellation
- install Ubuntu binary packages using `r2u-setup` on Linux runners

## Testing
- `R CMD check` *(fails: R not found)*

------
https://chatgpt.com/codex/tasks/task_e_684358b6a40483268036763c8e6a753a