### PR TITLE
Fix R workflow cache path

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Cache R packages
         uses: actions/cache@v4
         with:
-          path: ${{ runner.tool_cache }}/R
+          path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ matrix.r-version }}
           restore-keys: |
             ${{ runner.os }}-r-


### PR DESCRIPTION
## Summary
- adjust caching path in `.github/workflows/r.yml` to use `$R_LIBS_USER`

## Testing
- `git commit`

------
https://chatgpt.com/codex/tasks/task_e_684359cb00b08326be4cbe10713274c7