### PR TITLE
Fix Bioconductor install step

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -60,6 +60,8 @@ jobs:
 
       # 4) Install bioconductor manager and Bioconductor dependencies:
       - name: Install Bioconductor packages
+        env:
+          CRAN: https://cloud.r-project.org
         run: |
           Rscript -e 'if (!requireNamespace("BiocManager", quietly = TRUE)) install.packages("BiocManager")'
           # Install any Bioconductor packages listed in DESCRIPTION (Imports/Suggests).


### PR DESCRIPTION
## Summary
- set the CRAN mirror for the `Install Bioconductor packages` step

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435d6e6e0c8326ac3558139aa3fef0