### PR TITLE
Fix R package cache key

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -47,8 +47,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ matrix.r-version }}
+          key: ${{ runner.os }}-r-${{ matrix.r-version }}-${{ hashFiles('**/DESCRIPTION') }}
           restore-keys: |
+            ${{ runner.os }}-r-${{ matrix.r-version }}-
             ${{ runner.os }}-r-
 
       # 3) Set up Pandoc (needed for vignettes, pkgdown, etc.):


### PR DESCRIPTION
## Summary
- refine R package cache key with `hashFiles('**/DESCRIPTION')`

## Testing
- `yamllint .github/workflows/r.yml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68436a17dcb883269ad1ec033a42da5d