### PR TITLE
Fix skipped tests

### DIFF
--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -77,24 +77,7 @@ test_that("epi_plot_list", {
 ######################
 
 ######################
-print("Function being tested: epi_plot_grid_size")
-# Generate plots:
-for (i in names(my_plot_list)) {
-  # print(i)
-  # my_plot_list[[i]] <- ggplot2::qplot(data = df, y = , geom = 'boxplot')
-  my_plot_list[[i]] <- ggplot2::ggplot(df, aes_string(y = i)) + geom_boxplot()
-}
-# Not in use but keep tests:
-# Calculate how many plots can be passed to one grid (one page):
-# grid_size <- epi_plot_grid_size(my_plot_list)
-# grid_size
-# Not exported so errors with 'could not find function', leave as reference though
-test_that("epi_plot_grid_size", {
-#   expect_output(str(grid_size), 'ncol_grid: num 2')
-#   expect_output(str(grid_size), 'nrow_grid: num 1')
-  }
-  )
-######################
+
 
 ######################
 print("Function being tested: epi_plots_to_grid")
@@ -112,8 +95,14 @@ test_that("epi_plots_to_grid", {
 print("Function being tested: epi_plot_cow_save")
 
 test_that("epi_plot_cow_save", {
-  # TO DO: output is a plot saved to disk, see code above
-  # epi_plot_cow_save(file_name = 'plots_1.pdf', plot_grid = my_plot_grid)
+  skip_if_not_installed("cowplot")
+  tmp_file <- tempfile(fileext = ".pdf")
+  p <- ggplot2::ggplot(mtcars, ggplot2::aes(mpg, wt)) +
+    ggplot2::geom_point()
+  g <- cowplot::plot_grid(p)
+  epi_plot_cow_save(file_name = tmp_file, plot_grid = g)
+  expect_true(file.exists(tmp_file))
+  unlink(tmp_file)
   }
   )
 ######################
@@ -262,14 +251,7 @@ test_that("epi_plot_heatmap", {
 ######################
 
 ######################
-print("Function being tested: epi_plot_volcano")
 
-test_that("epi_plot_volcano", {
-  # TO DO: test plot output, needs example code
-  # Deprecated, just use limma::volcanoplot()
-}
-)
-######################
 
 # TO DO: missing tests for, moved this to blurbs, update properly and move back to R/
 # epi_plot_en_masse

--- a/tests/testthat/test-utility.R
+++ b/tests/testthat/test-utility.R
@@ -36,7 +36,11 @@ library(iterators)
 print("Function being tested: epi_utils_multicore")
 
 test_that("epi_utils_multicore sequential", {
-  skip_on_ci()
+  skip_if_not_installed("future")
+  skip_if_not_installed("doFuture")
+  skip_if_not_installed("foreach")
+  skip_if_not_installed("iterators")
+  skip_if_not_installed("parallel")
   epi_utils_multicore(num_cores = 1,
                       future_plan = 'sequential')
   core_s <- capture.output(epi_utils_multicore(num_cores = 1,
@@ -53,7 +57,12 @@ test_that("epi_utils_multicore sequential", {
 )
 
 test_that("epi_utils_multicore multi", {
-  skip_on_ci()
+  skip_if_not_installed("future")
+  skip_if_not_installed("doFuture")
+  skip_if_not_installed("foreach")
+  skip_if_not_installed("iterators")
+  skip_if_not_installed("parallel")
+  skip_if(parallel::detectCores() < 2, "Not enough cores")
   epi_utils_multicore(num_cores = 2,
                       future_plan = 'multisession')
   core_m <- capture.output(epi_utils_multicore(num_cores = 2,


### PR DESCRIPTION
## Summary
- remove unused grid size and volcano plot tests
- add check for saved output to epi_plot_cow_save test
- run parallel tests when packages and cores are available

## Testing
- `R -q -e 'devtools::test()'` *(fails: there is no package called ‘devtools’)*

------
https://chatgpt.com/codex/tasks/task_e_68439fd60ed48326af55d7b51f517271