### PR TITLE
Fix plotting and future tests

### DIFF
--- a/R/epi_plot_heatmap.R
+++ b/R/epi_plot_heatmap.R
@@ -55,7 +55,18 @@ epi_plot_heatmap <- function(cormat_melted = 'cormat_all$cormat_melted_r',
     stop('Package ggplot2 needed for this function to work. Please install it.',
          call. = FALSE)
   }
-  heat_map <- ggplot2::ggplot(data = as.data.frame(cormat_melted),
+  df <- as.data.frame(cormat_melted)
+  if (!"value" %in% colnames(df)) {
+    if ("correlation" %in% colnames(df)) {
+      df$value <- df$correlation
+    } else if ("pvalue" %in% colnames(df)) {
+      df$value <- df$pvalue
+    } else {
+      stop('Column `value`, `correlation` or `pvalue` not found in cormat_melted')
+    }
+  }
+
+  heat_map <- ggplot2::ggplot(data = df,
                               ggplot2::aes(x = .data$Var1,
                                            y = .data$Var2,
                                            fill = .data$value)

--- a/tests/testthat/test-utility.R
+++ b/tests/testthat/test-utility.R
@@ -52,7 +52,11 @@ test_that("epi_utils_multicore sequential", {
   future_v %<-% {1 + 2}
   future_v
   expect_identical(future_v, 3)
-  future:::ClusterRegistry("stop")
+  if ("ClusterRegistry" %in% ls(getNamespace("future"), all.names = TRUE)) {
+    future:::ClusterRegistry("stop")
+  } else {
+    future::plan("sequential")
+  }
 }
 )
 
@@ -75,7 +79,11 @@ test_that("epi_utils_multicore multi", {
   future_v %<-% {1 + 2}
   future_v
   expect_identical(future_v, 3)
-  future:::ClusterRegistry("stop")
+  if ("ClusterRegistry" %in% ls(getNamespace("future"), all.names = TRUE)) {
+    future:::ClusterRegistry("stop")
+  } else {
+    future::plan("sequential")
+  }
   }
   )
 ######################


### PR DESCRIPTION
## Summary
- handle correlation matrices that use `correlation`/`pvalue` columns
- guard calls to `ClusterRegistry` in tests for future versions of the **future** package

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_6843a518e0c88326b15e05dc9a029cb8