### PR TITLE
Fix legend.position in heatmap triangle

### DIFF
--- a/R/epi_plot_heatmap_triangle.R
+++ b/R/epi_plot_heatmap_triangle.R
@@ -123,8 +123,9 @@ epi_plot_heatmap_triangle <- function(cormat_melted_triangle_r = NULL,
                      panel.background = ggplot2::element_rect(),
                      axis.ticks = ggplot2::element_blank(),
                      legend.justification = c(1, 0),
-                     legend.position = c(0.5, 0.8),
-                     legend.direction = 'horizontal') +
+                     legend.direction = "horizontal") +
+      ggplot2::theme(legend.position = "inside",
+                     legend.position.inside = c(0.5, 0.8)) +
       ggplot2::guides(fill = ggplot2::guide_colorbar(barwidth = 12,
                                                      barheight = 2,
                                                      title.position = 'top',


### PR DESCRIPTION
## Summary
- adjust `epi_plot_heatmap_triangle` to avoid `legend.position` deprecation

## Testing
- `R CMD check . --no-manual --no-build-vignettes` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844a10100908326975e84eff7836d35