### PR TITLE
[Fix] handle filenames without extension and relax numeric test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Language: en-GB
-Imports: 
+Imports:
     utils,
     stats,
     grDevices,
@@ -20,15 +20,15 @@ Imports:
     broom,
     dplyr,
     tibble,
-    tidyr
-Suggests: 
+    tidyr,
+    e1071,
+    purrr,
+    stringr
+Suggests:
     data.table,
     compare,
     stringi,
-    stringr,
     lubridate,
-    purrr,
-    e1071,
     Hmisc,
     ggplot2,
     cowplot,

--- a/R/epi_output_name.R
+++ b/R/epi_output_name.R
@@ -2,6 +2,7 @@
 #'
 #' @description Generate a simple output name, given a string (filename)
 #' splits at the last '.', drops the current suffix and adds the one provided.
+#' If `input_name` lacks a dot, the whole string is used as is.
 #'
 #' @param input_name string to split, usually an input file name
 #' previously saved as an object
@@ -25,8 +26,14 @@
 
 epi_output_name <- function(input_name = "",
                             suffix = ".tsv") {
-  # Split infile name at the last '.':
-  output_name <- strsplit(input_name, "[.]\\s*(?=[^.]+$)", perl = TRUE)[[1]][1]
-  output_name <- sprintf("%s%s", output_name, suffix)
+  if (is.na(input_name)) {
+    base <- "NA"
+  } else if (!grepl("\\.", input_name)) {
+    base <- input_name
+  } else {
+    base <- strsplit(input_name, "[.]\\s*(?=[^.]+$)", perl = TRUE)[[1]][1]
+  }
+  if (!nzchar(base)) base <- "NA"
+  output_name <- sprintf("%s%s", base, suffix)
   return(output_name)
 }

--- a/R/epi_stats_chars.R
+++ b/R/epi_stats_chars.R
@@ -54,8 +54,22 @@ epi_stats_chars <- function(df) {
     dplyr::summarise(
       n_missing = sum(is.na(Value)),
       complete_rate = mean(!is.na(Value)),
-      min_length = dplyr::if_else(n_missing < dplyr::n(), min(nchar(Value), na.rm = TRUE), NA_integer_),
-      max_length = dplyr::if_else(n_missing < dplyr::n(), max(nchar(Value), na.rm = TRUE), NA_integer_),
+      min_length = {
+        len <- nchar(Value)
+        if (all(is.na(len))) {
+          NA_integer_
+        } else {
+          min(len, na.rm = TRUE)
+        }
+      },
+      max_length = {
+        len <- nchar(Value)
+        if (all(is.na(len))) {
+          NA_integer_
+        } else {
+          max(len, na.rm = TRUE)
+        }
+      },
       empty = sum(Value == "", na.rm = TRUE),
       n_unique = dplyr::n_distinct(Value, na.rm = TRUE),
       whitespace = sum(stringr::str_trim(Value) == "" & Value != "", na.rm = TRUE)

--- a/tests/testthat/test-cleaning_functions.R
+++ b/tests/testthat/test-cleaning_functions.R
@@ -61,6 +61,7 @@ test_that("Test expected output after epi_clean_get_dups", {
 print("Function being tested: epi_clean_compare_dup_rows")
 
 test_that("Test expected output after epi_clean_compare_dup_rows", {
+  skip_if_not_installed("compare")
   # Check a few duplicated individuals:
   check_dups <- epi_clean_get_dups(df, "var_id", 1)
   val_id <- "1"

--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -122,8 +122,8 @@ test_that("epi_stats_numeric", {
   # desc_stats
   # dim(desc_stats)
   expect_equal(class(desc_stats), "data.frame")
-  expect_equal(as.character(desc_stats[1, "min"]), "-2.77832551031467")
-  expect_equal(as.character(desc_stats[1, "mean"]), "0.0461981587217921")
+  expect_equal(desc_stats$min, min(df$x), tolerance = 1e-8)
+  expect_equal(desc_stats$mean, mean(df$x), tolerance = 1e-8)
   expect_equal(desc_stats[1, "NA_percentage"], 0)
 })
 ######################


### PR DESCRIPTION
## What was changed and why
- avoid subscript issues in `epi_output_name` when filenames lack a dot
- loosen numeric expectations in `epi_stats_numeric` tests
- declare `e1071`, `purrr` and `stringr` as Imports to satisfy `R CMD check`

## Tests added
- updated `test-stats.R` numeric comparisons with tolerance

## Backward compatibility
- no breaking changes

## Code coverage change
- none

------
https://chatgpt.com/codex/tasks/task_e_6881a6fd039c83269b8bba2294a5c066