### PR TITLE
[Test] validate custom palette recycling for epi_plot_bar

### DIFF
--- a/tests/testthat/test-additional_coverage.R
+++ b/tests/testthat/test-additional_coverage.R
@@ -78,6 +78,21 @@ test_that("epi_plot_bar applies custom palette", {
   expect_equal(cols, c("red", "blue"))
 })
 
+test_that("epi_plot_bar with var_y uses custom palette across levels", {
+  df <- data.frame(group = factor(c("A", "B")), value = c(1, 2))
+  p <- epi_plot_bar(df,
+    var_x = "group",
+    var_y = "value",
+    custom_palette = "green"
+  )
+  scale_obj <- p$scales$scales[[1]]
+  expect_equal(scale_obj$scale_name, "manual")
+  cols <- scale_obj$palette(2)
+  expect_equal(cols, c("green", "green"))
+  first_stat <- class(p$layers[[1]]$stat)[1]
+  expect_equal(first_stat, "StatIdentity")
+})
+
 ######################
 print("Function being tested: epi_read with custom NA strings")
 


### PR DESCRIPTION
1. **What was changed** and why
   - Added a new unit test verifying that `epi_plot_bar()` properly recycles a single-colour palette when plotting with `var_y`.
   - The test also checks that a `scale_fill_manual` layer is added and that the first layer uses `stat = "identity"`.
2. **Tests added**
   - `tests/testthat/test-additional_coverage.R`
3. **Backward compatibility**
   - No breaking changes.
4. **Code coverage change**
   - Minor increase due to new test.

------
https://chatgpt.com/codex/tasks/task_e_68825e159bc48326aa3d808081473fe6