### PR TITLE
[Test] verify epi_plot_heatmap value handling

### DIFF
--- a/tests/testthat/test-epi_plot_heatmap_value.R
+++ b/tests/testthat/test-epi_plot_heatmap_value.R
@@ -1,0 +1,44 @@
+context("epi_plot_heatmap value handling")
+
+library(episcout)
+library(testthat)
+
+# small helper data frames
+corr_df <- data.frame(
+  Var1 = "a",
+  Var2 = "b",
+  correlation = 0.5
+)
+
+pval_df <- data.frame(
+  Var1 = "a",
+  Var2 = "b",
+  pvalue = 0.1
+)
+
+no_val_df <- data.frame(
+  Var1 = "a",
+  Var2 = "b"
+)
+
+
+test_that("correlation column is used as value", {
+  p <- epi_plot_heatmap(corr_df, title = "Custom")
+  expect_s3_class(p, "ggplot")
+  expect_true(all(p$data$value == corr_df$correlation))
+  expect_equal(p$labels$title, "Custom")
+})
+
+
+test_that("pvalue column is used as value", {
+  p <- epi_plot_heatmap(pval_df)
+  expect_true(all(p$data$value == pval_df$pvalue))
+})
+
+
+test_that("error when no value column", {
+  expect_error(
+    epi_plot_heatmap(no_val_df),
+    "Column `value`, `correlation` or `pvalue` not found"
+  )
+})

--- a/tests/testthat/test-epi_plot_heatmap_value.R
+++ b/tests/testthat/test-epi_plot_heatmap_value.R
@@ -1,4 +1,3 @@
-context("epi_plot_heatmap value handling")
 
 library(episcout)
 library(testthat)


### PR DESCRIPTION
1. **What was changed** and why
   - Added a new regression test to ensure `epi_plot_heatmap()` correctly derives a `value` column from `correlation` or `pvalue` fields and errors when neither is supplied.
   - Test also confirms that custom titles propagate into the returned ggplot object.
2. **Tests added**
   - `test-epi_plot_heatmap_value.R`
3. **Backward compatibility**
   - No breaking changes; adds test coverage only.
4. **Code coverage change**
   - Minor increase from additional test.

------
https://chatgpt.com/codex/tasks/task_e_68825e0ddef08326bc7e5336478d481f