### PR TITLE
[Fix] adjust scale_name assertion for ggplot2 3.5

### DIFF
--- a/tests/testthat/test-additional_coverage.R
+++ b/tests/testthat/test-additional_coverage.R
@@ -80,13 +80,14 @@ test_that("epi_plot_bar applies custom palette", {
 
 test_that("epi_plot_bar with var_y uses custom palette across levels", {
   df <- data.frame(group = factor(c("A", "B")), value = c(1, 2))
-  p <- epi_plot_bar(df,
+  p <- epi_plot_bar(
+    df,
     var_x = "group",
     var_y = "value",
     custom_palette = "green"
   )
   scale_obj <- p$scales$scales[[1]]
-  expect_equal(scale_obj$scale_name, "manual")
+  expect_true(is.null(scale_obj$scale_name) || scale_obj$scale_name == "manual")
   cols <- scale_obj$palette(2)
   expect_equal(cols, c("green", "green"))
   first_stat <- class(p$layers[[1]]$stat)[1]


### PR DESCRIPTION
## What was changed and why
- Updated the unit test for `epi_plot_bar` to accept `scale_name` being `NULL` or "manual" to support changes in ggplot2 >= 3.5 where the field is `NULL`.

## Tests added
- Modified `tests/testthat/test-additional_coverage.R` to handle both cases.

## Backward compatibility
- No breaking changes. Test now works with older and newer ggplot2 versions.

## Code coverage change
- Coverage remains around 72%.


------
https://chatgpt.com/codex/tasks/task_e_6883d71f4ae08326b8835882dd45e12d