### PR TITLE
[Test] Verify epi_utils_log default output

### DIFF
--- a/tests/testthat/test-utility.R
+++ b/tests/testthat/test-utility.R
@@ -114,6 +114,26 @@ test_that("epi_utils_log writes log to file", {
   unlink(log_file)
 })
 
+test_that("epi_utils_log uses default name with no arguments", {
+  withr::with_tempdir({
+    file <- paste0("session_", Sys.Date(), "_log.txt")
+    expect_invisible(epi_utils_log())
+    expect_true(file.exists(file))
+    expect_true(grepl("R version", readLines(file, n = 1)))
+    unlink(file)
+  })
+})
+
+test_that("epi_utils_log ignores numeric input", {
+  withr::with_tempdir({
+    file <- paste0("session_", Sys.Date(), "_log.txt")
+    expect_invisible(epi_utils_log(123))
+    expect_true(file.exists(file))
+    expect_true(grepl("R version", readLines(file, n = 1)))
+    unlink(file)
+  })
+})
+
 print("Function being tested: epi_utils_session")
 
 test_that("epi_utils_session saves selected objects", {

--- a/tests/testthat/test-utility.R
+++ b/tests/testthat/test-utility.R
@@ -126,7 +126,7 @@ test_that("epi_utils_log uses default name with no arguments", {
 
 test_that("epi_utils_log ignores numeric input", {
   withr::with_tempdir({
-    file <- paste0("session_", Sys.Date(), "_log.txt")
+    file <- default_log_file_name()
     expect_invisible(epi_utils_log(123))
     expect_true(file.exists(file))
     expect_true(grepl("R version", readLines(file, n = 1)))


### PR DESCRIPTION
1. **What was changed**
   - Added new tests for `epi_utils_log` default behaviour in `tests/testthat/test-utility.R`.
2. **Tests added**
   - `epi_utils_log` now tested with no arguments and with numeric input to ensure default naming.
3. **Backward compatibility**
   - No breaking changes.
4. **Code coverage change**
   - Minor increase from additional test cases.

------
https://chatgpt.com/codex/tasks/task_e_6883dc5ab794832696d8a85ae5c8c5a3