### PR TITLE
[Test] cover epi_output_name edge cases

### DIFF
--- a/tests/testthat/test-epi_output_name.R
+++ b/tests/testthat/test-epi_output_name.R
@@ -1,0 +1,11 @@
+context("epi_output_name")
+
+test_that("NA and empty inputs produce 'NA.tsv'", {
+  expect_equal(epi_output_name(NA_character_), "NA.tsv")
+  expect_equal(epi_output_name(""), "NA.tsv")
+})
+
+test_that("custom suffix and dot handling", {
+  expect_equal(epi_output_name("nofile", suffix = ".csv"), "nofile.csv")
+  expect_equal(epi_output_name("a.b.c", suffix = ".txt"), "a.b.txt")
+})

--- a/tests/testthat/test-epi_output_name.R
+++ b/tests/testthat/test-epi_output_name.R
@@ -1,4 +1,3 @@
-context("epi_output_name")
 
 test_that("NA and empty inputs produce 'NA.tsv'", {
   expect_equal(epi_output_name(NA_character_), "NA.tsv")


### PR DESCRIPTION
## What was changed and why
- Added new `test-epi_output_name.R` to cover edge cases such as NA and empty inputs, custom suffixes, and names with multiple dots.

## Tests added
- `tests/testthat/test-epi_output_name.R`

## Backward compatibility
- No breaking changes.

## Code coverage change
- Minor increase due to added tests.

------
https://chatgpt.com/codex/tasks/task_e_6883dc33cd448326a73f664ce035c093