### PR TITLE
[Test] Verify epi_utils_log default output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Suggests:
     vdiffr,
     reshape2,
     covr,
+    withr,
     roxygen2,
     mice
 Roxygen: list(markdown = TRUE)

--- a/tests/testthat/test-utility.R
+++ b/tests/testthat/test-utility.R
@@ -114,6 +114,28 @@ test_that("epi_utils_log writes log to file", {
   unlink(log_file)
 })
 
+test_that("epi_utils_log uses default name with no arguments", {
+  skip_if_not_installed("withr")
+  withr::with_tempdir({
+    file <- paste0("session_", Sys.Date(), "_log.txt")
+    expect_invisible(epi_utils_log())
+    expect_true(file.exists(file))
+    expect_true(grepl("R version", readLines(file, n = 1)))
+    unlink(file)
+  })
+})
+
+test_that("epi_utils_log ignores numeric input", {
+  skip_if_not_installed("withr")
+  withr::with_tempdir({
+    file <- paste0("session_", Sys.Date(), "_log.txt")
+    expect_invisible(epi_utils_log(123))
+    expect_true(file.exists(file))
+    expect_true(grepl("R version", readLines(file, n = 1)))
+    unlink(file)
+  })
+})
+
 print("Function being tested: epi_utils_session")
 
 test_that("epi_utils_session saves selected objects", {

--- a/tests/testthat/test-utility.R
+++ b/tests/testthat/test-utility.R
@@ -131,7 +131,7 @@ test_that("epi_utils_log ignores numeric input", {
     file <- paste0("session_", Sys.Date(), "_log.txt")
     expect_invisible(epi_utils_log(123))
     expect_true(file.exists(file))
-    expect_true(grepl("R version", readLines(file, n = 1)))
+    expect_true(file.exists(file) && length(readLines(file)) > 0 && any(grepl("R version", readLines(file))))
     unlink(file)
   })
 })

--- a/tests/testthat/test-utility.R
+++ b/tests/testthat/test-utility.R
@@ -120,7 +120,7 @@ test_that("epi_utils_log uses default name with no arguments", {
     file <- paste0("session_", Sys.Date(), "_log.txt")
     expect_invisible(epi_utils_log())
     expect_true(file.exists(file))
-    expect_true(grepl("R version", readLines(file, n = 1)))
+    expect_true(any(grepl("R version", readLines(file))))
     unlink(file)
   })
 })


### PR DESCRIPTION
1. **What was changed**
   - Added `withr` to `Suggests` and skipped new log tests when not installed.
   - Updated tests verifying default log file creation for `epi_utils_log()`.
2. **Tests added**
   - `epi_utils_log` tested with no args and numeric input; session info captured.
3. **Backward compatibility**
   - No breaking changes.
4. **Code coverage change**
   - Coverage remains around 83%.

------
https://chatgpt.com/codex/tasks/task_e_6883dc5ab794832696d8a85ae5c8c5a3