### PR TITLE
[Fix] Resolve CodeFactor suggestions

### DIFF
--- a/R/epi_plot_heatmap_triangle.R
+++ b/R/epi_plot_heatmap_triangle.R
@@ -151,5 +151,5 @@ epi_plot_heatmap_triangle <- function(cormat_melted_triangle_r = NULL,
       title.position = "top",
       title.hjust = 0.5
     ))
-  return(heatmap_triangle)
+  heatmap_triangle
 }

--- a/tests/testthat/test-missing-functions.R
+++ b/tests/testthat/test-missing-functions.R
@@ -110,15 +110,15 @@ print("Function being tested: truncate_name and make_unique_name")
 
 test_that("truncate_name limits length", {
   long <- paste(rep("a", 35), collapse = "")
-  expect_equal(episcout:::truncate_name(long), substr(long, 1, 29))
-  expect_equal(episcout:::truncate_name("short"), "short")
+  expect_equal(getFromNamespace("truncate_name", "episcout")(long), substr(long, 1, 29))
+  expect_equal(getFromNamespace("truncate_name", "episcout")("short"), "short")
 })
 
 test_that("make_unique_name generates unique names", {
   names1 <- c("Sheet1", "Sheet2")
-  expect_equal(episcout:::make_unique_name("Sheet3", names1), "Sheet3")
+  expect_equal(getFromNamespace("make_unique_name", "episcout")("Sheet3", names1), "Sheet3")
   names2 <- c("Sheet", "Sheet_2", "Sheet_3")
-  expect_equal(episcout:::make_unique_name("Sheet", names2), "Sheet_4")
+  expect_equal(getFromNamespace("make_unique_name", "episcout")("Sheet", names2), "Sheet_4")
   names3 <- c("name")
-  expect_equal(episcout:::make_unique_name("NAME", names3), "NAME_2")
+  expect_equal(getFromNamespace("make_unique_name", "episcout")("NAME", names3), "NAME_2")
 })

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -25,7 +25,7 @@ context("dummy_tests_vdiffr") # this will be the name that the folder wil get as
 # XXXX/episcout/tests/figs/distributions
 test_that("histograms draw correctly - vdiffr dummy run", {
   skip_on_ci()
-#  skip("vdiffr snapshot skipped")
+  #  skip("vdiffr snapshot skipped")
   hist_ggplot <- ggplot(mtcars, aes(disp)) +
     geom_histogram()
   vdiffr::expect_doppelganger("ggplot2 histogram", hist_ggplot)
@@ -105,7 +105,7 @@ test_that("epi_plot_list", {
 print("Function being tested: epi_plots_to_grid")
 # Pass to a grid and save to file:
 # length(my_plot_list)
-my_plot_grid <- epi_plots_to_grid(my_plot_list[1:length(my_plot_list)])
+my_plot_grid <- epi_plots_to_grid(my_plot_list[seq_along(my_plot_list)])
 
 test_that("epi_plots_to_grid", {
   skip_on_ci()
@@ -136,7 +136,7 @@ print("Function being tested: epi_plot_hist")
 
 test_that("epi_plot_hist", {
   skip_on_ci()
-#  skip("vdiffr snapshot skipped")
+  #  skip("vdiffr snapshot skipped")
   # my_hist_plot <- epi_plot_hist(df, 'x') # pass with quotes as using ggplot2::aes_string()
   # Change the bins:
   my_hist_plot <- epi_plot_hist(df, "x", breaks = seq(-3, 3, by = 1))
@@ -176,7 +176,7 @@ print("Function being tested: epi_plot_box")
 
 test_that("epi_plot_box", {
   skip_on_ci()
-#  skip("vdiffr snapshot skipped")
+  #  skip("vdiffr snapshot skipped")
   # Boxplot of one variable:
   my_boxplot <- epi_plot_box(df, var_y = "x")
   vdiffr::expect_doppelganger("epi_plot_box_1_var", my_boxplot)
@@ -209,7 +209,7 @@ test_that("epi_plot_box", {
 print("Function being tested: epi_plot_bar")
 test_that("epi_plot_bar", {
   skip_on_ci()
-#  skip("vdiffr snapshot skipped")
+  #  skip("vdiffr snapshot skipped")
   # df
   # lapply(df, class)
   # Barplot for single variable:
@@ -248,7 +248,7 @@ print("Functions being tested: epi_plot_heatmap and epi_plot_heatmap_triangle")
 
 test_that("epi_plot_heatmap", {
   skip_on_ci()
-#  skip("vdiffr snapshot skipped")
+  #  skip("vdiffr snapshot skipped")
   # Set-up data:
   df[, "y"] <- as.integer(df[, "y"])
   df_corr <- df %>% select_if(~ epi_clean_cond_numeric(.))

--- a/tests/testthat/test-utility.R
+++ b/tests/testthat/test-utility.R
@@ -58,7 +58,7 @@ test_that("epi_utils_multicore sequential", {
   future_v
   expect_identical(future_v, 3)
   if ("ClusterRegistry" %in% ls(getNamespace("future"), all.names = TRUE)) {
-    future:::ClusterRegistry("stop")
+    getFromNamespace("ClusterRegistry", "future")("stop")
   } else {
     future::plan("sequential")
   }
@@ -94,7 +94,7 @@ test_that("epi_utils_multicore multi", {
   future_v
   expect_identical(future_v, 3)
   if ("ClusterRegistry" %in% ls(getNamespace("future"), all.names = TRUE)) {
-    future:::ClusterRegistry("stop")
+    getFromNamespace("ClusterRegistry", "future")("stop")
   } else {
     future::plan("sequential")
   }


### PR DESCRIPTION
## What was changed and why
- address CodeFactor warnings in unit tests and example plotting code
- replaced `1:length` with `seq_along`
- avoid `:::`, using `getFromNamespace` instead
- removed unnecessary `return()` in plotting helper

## Tests added
- existing testthat suite ran via `devtools::check`

## Backward compatibility
- no breaking changes

## Code coverage change
- none

------
https://chatgpt.com/codex/tasks/task_e_688aa73126f88326abb9f4439f56dceb