### PR TITLE
[Fix] Remove unnecessary c() call

### DIFF
--- a/tests/testthat/test-missing-functions.R
+++ b/tests/testthat/test-missing-functions.R
@@ -119,6 +119,6 @@ test_that("make_unique_name generates unique names", {
   expect_equal(getFromNamespace("make_unique_name", "episcout")("Sheet3", names1), "Sheet3")
   names2 <- c("Sheet", "Sheet_2", "Sheet_3")
   expect_equal(getFromNamespace("make_unique_name", "episcout")("Sheet", names2), "Sheet_4")
-  names3 <- c("name")
+  names3 <- "name"
   expect_equal(getFromNamespace("make_unique_name", "episcout")("NAME", names3), "NAME_2")
 })


### PR DESCRIPTION
## What was changed and why
- removed an extraneous `c()` call around a constant in the test `test-missing-functions.R` as flagged by CodeFactor

## Tests added
- none; existing tests updated

## Backward compatibility
- no breaking changes

## Code coverage change
- none

------
https://chatgpt.com/codex/tasks/task_e_688ab17d8f8883268ff9c78e0a7dc760