### PR TITLE
[Fix] Stabilize empty tibble test in stats summary

### DIFF
--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -254,11 +254,9 @@ test_that("epi_stats_summary, epi_stats_tidy and epi_stats_format", {
     class_type = "chr_fct",
     action = "codes_only"
   )
-  # as.data.frame(stat_sum_zero)
-  # class(stat_sum_zero)
+  # tibble with no rows when codes are absent
   expect_equal(class(stat_sum_zero)[2], "tbl")
-  # TO DO: add back but failing at the moment on travis, passes locally (04/June/2019)
-  # expect_equal(as.character(as.data.frame(stat_sum_zero))[1], "character(0)")
+  expect_equal(nrow(stat_sum_zero), 0)
   #####
 })
 ######################

--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -255,7 +255,7 @@ test_that("epi_stats_summary, epi_stats_tidy and epi_stats_format", {
     action = "codes_only"
   )
   # tibble with no rows when codes are absent
-  expect_equal(class(stat_sum_zero)[2], "tbl")
+  expect_true(tibble::is_tibble(stat_sum_zero))
   expect_equal(nrow(stat_sum_zero), 0)
   #####
 })


### PR DESCRIPTION
## What was changed and why
- Replace fragile expectation in `test-stats.R` with a direct check that `epi_stats_summary` returns a tibble with zero rows when codes are absent.

## Tests added
- Updated test `test-stats.R` and ran `devtools::test` to confirm all tests pass.

## Backward compatibility
- No breaking changes; behavior remains the same.

## Code coverage change
- Coverage remains at ~83% (no change).


------
https://chatgpt.com/codex/tasks/task_e_68aca05de7688326a3afb5bbeaba2218