### PR TITLE
[Fix] Clarify edge-case handling in epi_stats_count_outliers

### DIFF
--- a/R/epi_stats_count_outliers.R
+++ b/R/epi_stats_count_outliers.R
@@ -38,20 +38,24 @@
 #' @importFrom grDevices boxplot.stats
 #'
 
-# TO DO:
-# Clean-up, stop exporting as little value in having it as individual wrapper
-
+#' @details
+#' Returns 0 for empty or all-`NA` vectors and raises an error when `coef`
+#' is negative. Setting `coef` to `0` disables outlier detection.
 epi_stats_count_outliers <- function(num_vec = NULL,
                                      coef = 1.5,
                                      ...) {
-  if (coef == 0) {
+  if (is.null(num_vec) || !is.numeric(num_vec)) {
+    stop("num_vec must be a numeric vector")
+  }
+  if (!is.numeric(coef) || length(coef) != 1) {
+    stop("coef must be a single numeric value")
+  }
+  if (coef < 0) {
+    stop("coef must be non-negative")
+  }
+  if (coef == 0 || length(num_vec) == 0 || all(is.na(num_vec))) {
     return(0L)
   }
-  # if(method == 'SD') {
-  # get_SD <- sd(num_vec, na.rm = na.rm)
-  # count_above <- length(get_SD * )
-  # }
-  # if(method == 'IQR') {}
   q1 <- stats::quantile(num_vec, 0.25, na.rm = TRUE, type = 7)
   q3 <- stats::quantile(num_vec, 0.75, na.rm = TRUE, type = 7)
   iqr_val <- q3 - q1
@@ -61,16 +65,9 @@ epi_stats_count_outliers <- function(num_vec = NULL,
   outliers
 }
 
-# TO DO: add:
-# SD * eg 5
-# (IQR * 1.5) * 1.5 inner (or 3 for outer)
-# See:
-# https://stats.stackexchange.com/questions/350256/iterative-outlier-diagnostic?rq=1
-# regression - Iterative outlier diagnostic - Cross Validated
-# https://stats.stackexchange.com/questions/38001/detecting-outliers-using-standard-deviations?rq=1
-# Detecting outliers using standard deviations - Cross Validated
-# https://stats.stackexchange.com/questions/175999/determine-outliers-using-iqr-or-standard-deviation?rq=1
-# Determine outliers using IQR or standard deviation? - Cross Validated
+# Alternative thresholds such as multiples of the standard deviation or
+# inner/outer fences (e.g. 3 * IQR) are not currently implemented but may
+# be explored in future iterations.
 
 # Using the Qn estimator to avoid assuming that the underlying distribution
 # is symmetric:

--- a/man/epi_stats_count_outliers.Rd
+++ b/man/epi_stats_count_outliers.Rd
@@ -21,6 +21,10 @@ epi_stat_count_outliers() counts how many outliers a vector has
 using a univariate approach. Returns the number of observations that are greater than
 the cutoff. Outliers are detected with the Tukey method (above and below coef * IQR).
 }
+\details{
+Returns 0 for empty or all-\code{NA} vectors and raises an error when \code{coef}
+is negative. Setting \code{coef} to \code{0} disables outlier detection.
+}
 \note{
 coef = 0 returns no outliers, see ?boxplot.stats
 An alternative, not implemented, is to consider those eg > 5 * SD

--- a/tests/testthat/test-epi_stats_count_outliers.R
+++ b/tests/testthat/test-epi_stats_count_outliers.R
@@ -1,0 +1,18 @@
+test_that("coef zero returns zero outliers", {
+  expect_equal(epi_stats_count_outliers(num_vec = c(1, 2, 100), coef = 0), 0L)
+})
+
+test_that("negative coef errors", {
+  expect_error(epi_stats_count_outliers(num_vec = 1:5, coef = -1))
+})
+
+test_that("non-numeric vector errors", {
+  expect_error(epi_stats_count_outliers(num_vec = c("a", "b")))
+})
+
+test_that("all NA vector returns zero", {
+  expect_equal(
+    epi_stats_count_outliers(num_vec = c(NA_real_, NA_real_, NA_real_)),
+    0L
+  )
+})


### PR DESCRIPTION
## What was changed and why
- Validate inputs and handle empty or all-NA vectors in `epi_stats_count_outliers`
- Document limitations of alternative thresholds
- Add unit tests for `epi_stats_count_outliers`

## Tests added
- `tests/testthat/test-epi_stats_count_outliers.R`

## Backward compatibility
- No breaking changes expected

## Code coverage change
- No significant change

------
https://chatgpt.com/codex/tasks/task_e_68aca0953e948326972b6df79642b4d6