### PR TITLE
[Fix] update Excel export test to use named output file

### DIFF
--- a/tests/testthat/test-grob_files_to_excel.R
+++ b/tests/testthat/test-grob_files_to_excel.R
@@ -14,7 +14,7 @@ test_that("Excel file created and sheet names are unique", {
   write.table(df, file2, sep = "\t", row.names = FALSE)
   write.table(df, file3, sep = "\t", row.names = FALSE)
 
-  out_path <- epi_grob_to_excel(tmp, "combined")
+  out_path <- epi_grob_to_excel(tmp, output_file = file.path(tmp, "combined.xlsx"))
   expect_true(file.exists(out_path))
 
   wb <- openxlsx::loadWorkbook(out_path)


### PR DESCRIPTION
## What was changed and why
- corrected `grob_files_to_excel` test to pass the output file path via named argument, matching function signature and allowing `.txt` files to be detected

## Tests added
- `test-grob_files_to_excel.R` updated; ran `devtools::test`

## Backward compatibility
- no breaking changes

## Code coverage change
- none

------
https://chatgpt.com/codex/tasks/task_e_68af55f9f2fc83269f0f1995c1f34336