### PR TITLE
[Fix] Restore future plan in multicore utility

### DIFF
--- a/R/epi_utils_multicore.R
+++ b/R/epi_utils_multicore.R
@@ -59,6 +59,12 @@ epi_utils_multicore <- function(num_cores = NULL,
   # Set number of cores
   num_cores <- if (is.null(num_cores)) max(1, parallel::detectCores() - 1) else num_cores
 
+  # Capture existing plan and ensure it is restored on exit.
+  # Switching to 'sequential' ensures spawned workers are terminated.
+  prev_plan <- future::plan()
+  on.exit(future::plan("sequential"), add = TRUE)
+  on.exit(future::plan(prev_plan), add = TRUE)
+
   # Register doFuture and configure plan
   doFuture::registerDoFuture()
   if (identical(future_plan, "sequential")) {


### PR DESCRIPTION
## Summary
- Preserve any existing future plan before configuring parallel execution
- Reset to sequential and reinstate previous plan on exit to terminate workers cleanly

## Testing
- `Rscript -e "styler::style_pkg()"`
- `Rscript -e "lintr::lint_package()"` (warnings)
- `Rscript -e "devtools::test(reporter = 'summary')"`
- `Rscript -e "covr::report()"` (no output)
- `Rscript -e "devtools::check(manual = FALSE)"` (warning: qpdf missing; notes: compare, doFuture unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68b2059784e0832696b8ffc745a1eeb5