### PR TITLE
[Fix] Stabilize parallel plot tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,8 @@ Authors@R:
            family = "Berlanga-Taylor",
            role = c("aut", "cre"),
            email = "antoniojberlanga@gmail.com")
+Author: Antonio Berlanga-Taylor [aut, cre]
+Maintainer: Antonio Berlanga-Taylor <antoniojberlanga@gmail.com>
 Description: Facilitates cleaning, exploring and visualising large-ish datasets (hundreds of thousands to millions of observations with tens to hundreds of variables). These are mostly wrapper and convenience functions to pre-process (wrangle, explore, clean, etc.) data-sets. Assumes you're happy with tidyverse and the basics of data.table. 
 License: GPL-3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,6 @@ Suggests:
     survival,
     grid,
     ggthemes,
-    survival,
     future,
     doFuture,
     iterators,

--- a/R/global_vars.R
+++ b/R/global_vars.R
@@ -13,7 +13,8 @@ if (getRversion() >= "2.15.1") {
   utils::globalVariables(
     c(
       ".", "level", "variable", "label", "Column", "Variable", "Value",
-      "Statistic", "Var1", "n_missing", "x", "time", "surv", "count"
+      "Statistic", "Var1", "n_missing", "x", "time", "surv", "count",
+      "i", "v"
     )
   )
 }

--- a/tests/testthat/test-plot-parallel.R
+++ b/tests/testthat/test-plot-parallel.R
@@ -14,6 +14,13 @@ skip_if_not_installed("withr")
 skip_if_not_installed("ggplot2")
 skip_if_not_installed("cowplot")
 
+# Multisession futures start fresh R workers that must be able to attach
+# the installed package. devtools::test()/pkgload exposes the source tree to
+# the main process, but not as an installed package to worker processes.
+skip_if_not(dir.exists(file.path(system.file(package = "episcout"), "Meta")),
+  "parallel plot tests require episcout to be installed"
+)
+
 library(episcout)
 library(ggplot2)
 library(future)


### PR DESCRIPTION
### Motivation

- Prevent spurious failures of multisession parallel plotting tests when running tests from the source tree (`devtools::test()`/pkgload) because worker processes cannot attach the non-installed package. 
- Remove R CMD check NOTEs for undefined foreach iterator variables used by parallel helpers. 
- Clean up `DESCRIPTION` metadata by removing a duplicated `survival` entry in `Suggests`.

### Description

- Added a skip guard to `tests/testthat/test-plot-parallel.R` that skips multisession parallel plot tests unless the package is installed and worker processes can attach it (checks for `system.file(package = "episcout")/Meta`).
- Registered the foreach iterator symbols `"i"` and `"v"` in `R/global_vars.R` via `utils::globalVariables()` to silence R CMD check global-variable notes.
- Removed a duplicate `survival` entry from `Suggests` in `DESCRIPTION` to clean up package metadata.

### Testing

- Ran `Rscript -e "devtools::test(filter='plot-parallel', reporter='summary')"` which completed with the parallel plot tests skipped as intended.
- Ran `Rscript -e "devtools::test(reporter = 'summary')"` which completed successfully with expected skips for vdiffr/doFuture-related tests.
- Performed `R CMD build` and `R CMD check` on the package tarball which completed successfully with only vignette-related warnings and no remaining NOTE about the previously undefined globals after the fix; suggested packages `compare` and `doFuture` were installed in the test environment to allow full checks to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e02fe08b4832699b789db1f6e290d)