### PR TITLE
[Feature] Add synthetic data fixture tests

### DIFF
--- a/spec_driven_EDA_plan/docs/START_HERE.md
+++ b/spec_driven_EDA_plan/docs/START_HERE.md
@@ -24,19 +24,20 @@ operational source of truth for what happens next.
 | PR 1 external fixture files | Done | Fixture files are present under `tests/testthat/fixtures/blood_storage/`. |
 | PR 2 fixture-backed failing tests | Done | Tests are present and may fail until PR 3 implements the missing functions. |
 | PR 3 spec, schema and missingness implementation | Done | Spec, schema and missingness functions are implemented. |
-| PR 4 synthetic-data failing tests | Active | Follow Instruction 4 in `spec_driven_EDA_plan/docs/codex/tdd-first-codex-instructions.md`. |
-| Later synthetic, summary, plot, report and template work | Not started | Continue through the PR plan after PR 3. |
+| PR 4 synthetic-data failing tests | Done | Tests are present and may fail until PR 5 implements `generate_synthetic_data()`. |
+| PR 5 synthetic-data implementation | Active | Follow Instruction 5 in `spec_driven_EDA_plan/docs/codex/tdd-first-codex-instructions.md`. |
+| Later summary, plot, report and template work | Not started | Continue through the PR plan after PR 5. |
 
 ## Active PR
 
 ```text
-PR 4: Add failing synthetic-data tests
+PR 5: Implement synthetic-data generation
 ```
 
 Instruction:
 
 ```text
-Follow Instruction 4 in:
+Follow Instruction 5 in:
 spec_driven_EDA_plan/docs/codex/tdd-first-codex-instructions.md
 ```
 
@@ -53,26 +54,25 @@ spec_driven_EDA_plan/docs/codex/revised-pr-plan-tdd-first.md
 spec_driven_EDA_plan/docs/codex/review-checklist.md
 ```
 
-## PR 4 Scope
+## PR 5 Scope
 
 Must edit:
 
 ```text
-tests/testthat/test-eda_synthetic-fixtures.R
+R/eda_synthetic.R
 spec_driven_EDA_plan/docs/START_HERE.md
 ```
 
 May read:
 
 ```text
-tests/testthat/fixtures/blood_storage/blood_storage.csv
+tests/testthat/test-eda_synthetic-fixtures.R
 tests/testthat/fixtures/blood_storage/blood_storage_spec.csv
 ```
 
 Must not edit:
 
 ```text
-R/eda_synthetic.R
 R/eda_spec.R
 R/eda_schema.R
 R/eda_missing.R
@@ -87,7 +87,7 @@ inst/project-template/
 Expected test state:
 
 ```text
-PR 4 may leave tests failing until PR 5 implements generate_synthetic_data().
+PR 5 should make the synthetic-data tests pass.
 ```
 
 ## Closeout Rule

--- a/tests/testthat/test-eda_synthetic-fixtures.R
+++ b/tests/testthat/test-eda_synthetic-fixtures.R
@@ -1,0 +1,71 @@
+context("fixture-backed EDA synthetic-data tests")
+
+library(testthat)
+library(episcout)
+
+fixture_dir <- file.path("fixtures", "blood_storage")
+spec_path <- file.path(fixture_dir, "blood_storage_spec.csv")
+
+spec <- eda_spec(spec_path)
+
+split_levels <- function(x) {
+  strsplit(x, ";", fixed = TRUE)[[1]]
+}
+
+test_that("synthetic data has the same variable names as the specification", {
+  synthetic <- generate_synthetic_data(spec, n = 25, seed = 1)
+
+  expect_s3_class(synthetic, "data.frame")
+  expect_identical(names(synthetic), spec$name)
+})
+
+test_that("synthetic data has the requested row count", {
+  synthetic <- generate_synthetic_data(spec, n = 37, seed = 1)
+
+  expect_equal(nrow(synthetic), 37L)
+})
+
+test_that("synthetic categorical and binary values respect specification levels", {
+  synthetic <- generate_synthetic_data(spec, n = 100, seed = 1)
+
+  categorical_spec <- spec[spec$type %in% c("categorical", "binary") &
+    !is.na(spec$levels) & spec$levels != "", , drop = FALSE]
+
+  for (i in seq_len(nrow(categorical_spec))) {
+    name <- categorical_spec$name[i]
+    allowed_levels <- split_levels(categorical_spec$levels[i])
+    observed_values <- unique(as.character(stats::na.omit(synthetic[[name]])))
+
+    expect_true(
+      all(observed_values %in% allowed_levels),
+      info = paste(name, "contains values outside the specification levels")
+    )
+  }
+})
+
+test_that("synthetic numeric and integer values respect specification min and max", {
+  synthetic <- generate_synthetic_data(spec, n = 100, seed = 1)
+
+  ranged_spec <- spec[spec$type %in% c("numeric", "integer") &
+    !is.na(spec$min) & spec$min != "" &
+    !is.na(spec$max) & spec$max != "", , drop = FALSE]
+
+  for (i in seq_len(nrow(ranged_spec))) {
+    name <- ranged_spec$name[i]
+    min_value <- as.numeric(ranged_spec$min[i])
+    max_value <- as.numeric(ranged_spec$max[i])
+    observed_values <- stats::na.omit(synthetic[[name]])
+
+    expect_true(
+      all(observed_values >= min_value & observed_values <= max_value),
+      info = paste(name, "contains values outside the specification range")
+    )
+  }
+})
+
+test_that("fixed seed gives identical synthetic output", {
+  synthetic_a <- generate_synthetic_data(spec, n = 25, seed = 2024)
+  synthetic_b <- generate_synthetic_data(spec, n = 25, seed = 2024)
+
+  expect_identical(synthetic_a, synthetic_b)
+})


### PR DESCRIPTION
### Motivation

- Add TDD-style failing tests for synthetic data generation so implementation can be done in the next PR per the spec-first EDA plan.

### Description

- Add `tests/testthat/test-eda_synthetic-fixtures.R` which asserts that `generate_synthetic_data()` preserves specification variable names, returns the requested row count, respects categorical/binary `levels`, respects numeric/integer `min`/`max` ranges, and is deterministic with a fixed `seed`.
- Update `spec_driven_EDA_plan/docs/START_HERE.md` to mark PR 4 as Done and make PR 5 (implement synthetic-data generation) Active, and to update the edit/read/no-edit scope and expected test state.
- Do not implement `generate_synthetic_data()` in this change so the tests remain failing as intended for TDD.

### Testing

- Ran the test suite with `Rscript -e "devtools::test(reporter = 'summary')"`, which executed the package tests including the new synthetic-data tests.
- Existing tests mostly passed; the new synthetic-data tests produced errors because `generate_synthetic_data()` is not yet implemented, which is the expected TDD failure (5 test errors due to missing function).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f8372b4408326b6a332b6168d6680)