### PR TITLE
Add fixture-backed tests for EDA summaries and plots

### DIFF
--- a/spec_driven_EDA_plan/docs/START_HERE.md
+++ b/spec_driven_EDA_plan/docs/START_HERE.md
@@ -26,19 +26,20 @@ operational source of truth for what happens next.
 | PR 3 spec, schema and missingness implementation | Done | Spec, schema and missingness functions are implemented. |
 | PR 4 synthetic-data failing tests | Done | Tests are present and may fail until PR 5 implements `generate_synthetic_data()`. |
 | PR 5 synthetic-data implementation | Done | `generate_synthetic_data()` is implemented. |
-| PR 6 summary and plot failing tests | Active | Follow Instruction 6 in `spec_driven_EDA_plan/docs/codex/tdd-first-codex-instructions.md`. |
-| Later summary, plot, report and template work | Not started | Continue through the PR plan after PR 6. |
+| PR 6 summary and plot failing tests | Done | Tests are present and may fail until PR 7 implements `profile_summaries()` and `profile_plots()`. |
+| PR 7 summary and plot implementation | Active | Follow Instruction 7 in `spec_driven_EDA_plan/docs/codex/tdd-first-codex-instructions.md`. |
+| Later run, report and template work | Not started | Continue through the PR plan after PR 7. |
 
 ## Active PR
 
 ```text
-PR 6: Add failing summary and plot tests
+PR 7: Implement summaries and plots
 ```
 
 Instruction:
 
 ```text
-Follow Instruction 6 in:
+Follow Instruction 7 in:
 spec_driven_EDA_plan/docs/codex/tdd-first-codex-instructions.md
 ```
 
@@ -55,23 +56,23 @@ spec_driven_EDA_plan/docs/codex/revised-pr-plan-tdd-first.md
 spec_driven_EDA_plan/docs/codex/review-checklist.md
 ```
 
-## PR 6 Scope
+## PR 7 Scope
 
 Must edit:
 
 ```text
-tests/testthat/test-eda_summaries-fixtures.R
-tests/testthat/test-eda_plots-fixtures.R
+R/eda_summaries.R
+R/eda_plots.R
 spec_driven_EDA_plan/docs/START_HERE.md
 ```
 
 May read:
 
 ```text
+tests/testthat/test-eda_summaries-fixtures.R
+tests/testthat/test-eda_plots-fixtures.R
 tests/testthat/fixtures/blood_storage/blood_storage.csv
 tests/testthat/fixtures/blood_storage/blood_storage_spec.csv
-R/eda_summaries.R
-R/eda_plots.R
 ```
 
 Must not edit:
@@ -81,8 +82,6 @@ R/eda_spec.R
 R/eda_schema.R
 R/eda_missing.R
 R/eda_synthetic.R
-R/eda_summaries.R
-R/eda_plots.R
 R/run_eda.R
 R/eda_report.R
 inst/report-template/
@@ -92,7 +91,7 @@ inst/project-template/
 Expected test state:
 
 ```text
-PR 6 may leave tests failing until PR 7 implements `profile_summaries()` and `profile_plots()`.
+PR 7 is expected to make the PR 6 summary and plot tests pass by implementing `profile_summaries()` and `profile_plots()`.
 ```
 
 ## Closeout Rule

--- a/tests/testthat/test-eda_plots-fixtures.R
+++ b/tests/testthat/test-eda_plots-fixtures.R
@@ -1,0 +1,44 @@
+context("fixture-backed EDA plot tests")
+
+library(testthat)
+library(episcout)
+
+fixture_dir <- file.path("fixtures", "blood_storage")
+data_path <- file.path(fixture_dir, "blood_storage.csv")
+spec_path <- file.path(fixture_dir, "blood_storage_spec.csv")
+
+test_that("profile_plots returns one named plot object per specified variable", {
+  data <- read.csv(data_path, check.names = FALSE)
+  spec <- eda_spec(spec_path)
+
+  observed <- profile_plots(data, spec)
+
+  expect_type(observed, "list")
+  expect_named(observed, spec$name)
+  expect_equal(length(observed), nrow(spec))
+})
+
+test_that("profile_plots returns ggplot objects without checking visual appearance", {
+  skip_if_not_installed("ggplot2")
+
+  data <- read.csv(data_path, check.names = FALSE)
+  spec <- eda_spec(spec_path)
+
+  observed <- profile_plots(data, spec)
+
+  expect_true(all(vapply(observed, inherits, logical(1), what = "ggplot")))
+})
+
+test_that("profile_plots dispatches numeric and categorical fixture variables", {
+  skip_if_not_installed("ggplot2")
+
+  data <- read.csv(data_path, check.names = FALSE)
+  spec <- eda_spec(spec_path)
+
+  observed <- profile_plots(data, spec)
+
+  expect_s3_class(observed$Age, "ggplot")
+  expect_s3_class(observed$Units, "ggplot")
+  expect_s3_class(observed$RBC.Age.Group, "ggplot")
+  expect_s3_class(observed$Recurrence, "ggplot")
+})

--- a/tests/testthat/test-eda_summaries-fixtures.R
+++ b/tests/testthat/test-eda_summaries-fixtures.R
@@ -1,0 +1,92 @@
+context("fixture-backed EDA summary tests")
+
+library(testthat)
+library(episcout)
+
+fixture_dir <- file.path("fixtures", "blood_storage")
+data_path <- file.path(fixture_dir, "blood_storage.csv")
+spec_path <- file.path(fixture_dir, "blood_storage_spec.csv")
+
+make_expected_numeric_summary <- function(data, spec) {
+  numeric_spec <- spec[spec$type %in% c("numeric", "integer"), , drop = FALSE]
+
+  rows <- lapply(numeric_spec$name, function(name) {
+    values <- data[[name]]
+    data.frame(
+      name = name,
+      n = length(values),
+      n_missing = sum(is.na(values)),
+      mean = mean(values, na.rm = TRUE),
+      sd = stats::sd(values, na.rm = TRUE),
+      median = stats::median(values, na.rm = TRUE),
+      min = min(values, na.rm = TRUE),
+      max = max(values, na.rm = TRUE),
+      stringsAsFactors = FALSE
+    )
+  })
+
+  do.call(rbind, rows)
+}
+
+make_expected_categorical_summary <- function(data, spec) {
+  categorical_spec <- spec[spec$type %in% c("categorical", "binary"), , drop = FALSE]
+
+  rows <- lapply(categorical_spec$name, function(name) {
+    values <- data[[name]]
+    observed <- as.character(values[!is.na(values)])
+    levels <- strsplit(categorical_spec$levels[categorical_spec$name == name], ";", fixed = TRUE)[[1]]
+    counts <- vapply(levels, function(level) sum(observed == level), integer(1))
+
+    data.frame(
+      name = name,
+      level = levels,
+      n = as.integer(counts),
+      p = as.numeric(counts) / length(values),
+      stringsAsFactors = FALSE
+    )
+  })
+
+  do.call(rbind, rows)
+}
+
+test_that("profile_summaries returns numeric and categorical summary components", {
+  data <- read.csv(data_path, check.names = FALSE)
+  spec <- eda_spec(spec_path)
+
+  observed <- profile_summaries(data, spec)
+
+  expect_type(observed, "list")
+  expect_named(observed, c("numeric", "categorical"))
+  expect_s3_class(observed$numeric, "data.frame")
+  expect_s3_class(observed$categorical, "data.frame")
+})
+
+test_that("profile_summaries numeric output matches independent fixture calculations", {
+  data <- read.csv(data_path, check.names = FALSE)
+  spec <- eda_spec(spec_path)
+  expected <- make_expected_numeric_summary(data, spec)
+
+  observed <- profile_summaries(data, spec)
+
+  expect_equal(
+    as.data.frame(observed$numeric),
+    expected,
+    tolerance = 1e-12,
+    ignore_attr = TRUE
+  )
+})
+
+test_that("profile_summaries categorical output matches independent fixture calculations", {
+  data <- read.csv(data_path, check.names = FALSE)
+  spec <- eda_spec(spec_path)
+  expected <- make_expected_categorical_summary(data, spec)
+
+  observed <- profile_summaries(data, spec)
+
+  expect_equal(
+    as.data.frame(observed$categorical),
+    expected,
+    tolerance = 1e-12,
+    ignore_attr = TRUE
+  )
+})


### PR DESCRIPTION
### Motivation
- Add failing, fixture-backed tests to drive a spec-first implementation of summary profiling and plot dispatch for the EDA workflow. 
- Record progress in the PR plan so the next PR implements `profile_summaries()` and `profile_plots()` as the active task.

### Description
- Add `tests/testthat/test-eda_summaries-fixtures.R` which computes independent numeric/integer summaries and categorical/binary counts/proportions from the `blood_storage` fixture and asserts expected structure and values against `profile_summaries()` output. 
- Add `tests/testthat/test-eda_plots-fixtures.R` which asserts that `profile_plots()` returns a named list keyed by `spec$name`, has an element per spec row, and returns `ggplot` objects for representative variables. 
- Update `spec_driven_EDA_plan/docs/START_HERE.md` to mark PR 6 as Done and make PR 7 (implement summaries and plots) Active, and adjust the PR scope/expected test state accordingly. 
- No implementation of `profile_summaries()` or `profile_plots()` was added in this change; the tests are intentionally failing until the implementation PR. 

### Testing
- Ran `Rscript -e "devtools::document()"` which completed but emitted documentation/tooling warnings about the installed `roxygen2` version and some `@example`/`@inheritParams` notes. 
- Ran `Rscript -e "devtools::test(reporter = 'summary')"` which intentionally reported failing tests (6 errors) because `profile_summaries()` and `profile_plots()` are not yet implemented. 
- Ran `Rscript -e "devtools::check(manual = FALSE)"` which failed due to the same test errors and produced notes about unavailable suggested packages and missing `qpdf`; these failures are expected until PR 7 implements the missing functions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f8a8ab3ec83268ce7ab041e65f403)