### PR TITLE
Add run_eda fixture workflow tests and advance PR plan to implement run_eda

### DIFF
--- a/spec_driven_EDA_plan/docs/START_HERE.md
+++ b/spec_driven_EDA_plan/docs/START_HERE.md
@@ -28,19 +28,20 @@ operational source of truth for what happens next.
 | PR 5 synthetic-data implementation | Done | `generate_synthetic_data()` is implemented. |
 | PR 6 summary and plot failing tests | Done | Tests are present and may fail until PR 7 implements `profile_summaries()` and `profile_plots()`. |
 | PR 7 summary and plot implementation | Done | `profile_summaries()` and `profile_plots()` are implemented. |
-| PR 8 run_eda failing tests | Active | Follow Instruction 8 in `spec_driven_EDA_plan/docs/codex/tdd-first-codex-instructions.md`. |
-| Later run, report and template work | Not started | Continue through the PR plan after PR 8. |
+| PR 8 run_eda failing tests | Done | Tests are present and may fail until PR 9 implements `run_eda()`. |
+| PR 9 run_eda implementation | Active | Follow Instruction 9 in `spec_driven_EDA_plan/docs/codex/tdd-first-codex-instructions.md`. |
+| Later report and template work | Not started | Continue through the PR plan after PR 9. |
 
 ## Active PR
 
 ```text
-PR 8: Add failing run_eda tests
+PR 9: Implement run_eda()
 ```
 
 Instruction:
 
 ```text
-Follow Instruction 8 in:
+Follow Instruction 9 in:
 spec_driven_EDA_plan/docs/codex/tdd-first-codex-instructions.md
 ```
 
@@ -57,12 +58,12 @@ spec_driven_EDA_plan/docs/codex/revised-pr-plan-tdd-first.md
 spec_driven_EDA_plan/docs/codex/review-checklist.md
 ```
 
-## PR 8 Scope
+## PR 9 Scope
 
 Must edit:
 
 ```text
-tests/testthat/test-run_eda-fixtures.R
+R/run_eda.R
 spec_driven_EDA_plan/docs/START_HERE.md
 ```
 
@@ -76,6 +77,7 @@ tests/testthat/test-eda_schema-fixtures.R
 tests/testthat/test-eda_missing-fixtures.R
 tests/testthat/test-eda_summaries-fixtures.R
 tests/testthat/test-eda_plots-fixtures.R
+tests/testthat/test-run_eda-fixtures.R
 ```
 
 Must not edit:
@@ -87,7 +89,6 @@ R/eda_missing.R
 R/eda_synthetic.R
 R/eda_summaries.R
 R/eda_plots.R
-R/run_eda.R
 R/eda_report.R
 inst/report-template/
 inst/project-template/
@@ -96,7 +97,7 @@ inst/project-template/
 Expected test state:
 
 ```text
-PR 8 may leave tests failing until PR 9 implements `run_eda()`.
+PR 9 should make the run_eda fixture tests pass.
 ```
 
 ## Closeout Rule

--- a/tests/testthat/test-run_eda-fixtures.R
+++ b/tests/testthat/test-run_eda-fixtures.R
@@ -1,0 +1,81 @@
+context("fixture-backed run_eda workflow tests")
+
+library(testthat)
+library(episcout)
+
+fixture_dir <- file.path("fixtures", "blood_storage")
+data_path <- file.path(fixture_dir, "blood_storage.csv")
+spec_path <- file.path(fixture_dir, "blood_storage_spec.csv")
+
+expected_components <- c("metadata", "schema", "missing", "summaries", "plots")
+
+test_that("run_eda returns expected components for real fixture data", {
+  data <- read.csv(data_path, check.names = FALSE)
+  spec <- eda_spec(spec_path)
+
+  observed <- run_eda(data = data, spec = spec)
+
+  expect_type(observed, "list")
+  expect_named(observed, expected_components)
+  expect_s3_class(observed$metadata, "data.frame")
+  expect_s3_class(observed$schema, "data.frame")
+  expect_s3_class(observed$missing, "data.frame")
+  expect_type(observed$summaries, "list")
+  expect_type(observed$plots, "list")
+})
+
+test_that("run_eda real-data workflow matches component functions", {
+  data <- read.csv(data_path, check.names = FALSE)
+  spec <- eda_spec(spec_path)
+
+  observed <- run_eda(data = data, spec = spec)
+
+  expect_equal(observed$schema, check_schema(data, spec), ignore_attr = TRUE)
+  expect_equal(observed$missing, profile_missing(data, spec), ignore_attr = TRUE)
+  expect_equal(
+    observed$summaries,
+    profile_summaries(data, spec),
+    tolerance = 1e-12,
+    ignore_attr = TRUE
+  )
+  expect_named(observed$plots, spec$name)
+})
+
+test_that("run_eda supports synthetic fixture workflow", {
+  spec <- eda_spec(spec_path)
+
+  observed <- run_eda(
+    data = NULL,
+    spec = spec,
+    synthetic = TRUE,
+    n = 25,
+    seed = 2024
+  )
+
+  expect_type(observed, "list")
+  expect_named(observed, expected_components)
+  expect_equal(observed$metadata$synthetic, TRUE)
+  expect_equal(observed$metadata$n_rows, 25L)
+  expect_equal(observed$schema$status, rep("present", nrow(spec)))
+  expect_named(observed$plots, spec$name)
+})
+
+test_that("run_eda writes workflow outputs to a temporary output directory", {
+  data <- read.csv(data_path, check.names = FALSE)
+  spec <- eda_spec(spec_path)
+  output_dir <- tempfile("run-eda-fixture-")
+  dir.create(output_dir)
+
+  observed <- run_eda(data = data, spec = spec, output_dir = output_dir)
+
+  expect_true(dir.exists(output_dir))
+  expect_true(file.exists(file.path(output_dir, "metadata.csv")))
+  expect_true(file.exists(file.path(output_dir, "schema.csv")))
+  expect_true(file.exists(file.path(output_dir, "missing.csv")))
+  expect_true(file.exists(file.path(output_dir, "summary_numeric.csv")))
+  expect_true(file.exists(file.path(output_dir, "summary_categorical.csv")))
+  expect_equal(
+    names(utils::read.csv(file.path(output_dir, "schema.csv"), check.names = FALSE)),
+    names(observed$schema)
+  )
+})


### PR DESCRIPTION
### Motivation
- Add end-to-end, fixture-backed tests for the future `run_eda()` orchestration function and advance the PR roadmap so implementation of `run_eda()` is the next active task.

### Description
- Add `tests/testthat/test-run_eda-fixtures.R` containing real-data and synthetic-data workflow tests, parity checks against `check_schema()`, `profile_missing()`, and `profile_summaries()`, plot naming assertions, and temporary output-directory/CSV file checks.
- Update `spec_driven_EDA_plan/docs/START_HERE.md` to mark PR 8 as Done and make PR 9 (`Implement run_eda()`) the active next step, and adjust the PR scope and expected test state accordingly.

### Testing
- Ran `Rscript -e "devtools::test(filter = 'run_eda-fixtures', reporter = 'summary')"` which produced errors because `run_eda()` is intentionally not implemented yet, which is the expected TDD outcome for this PR.
- Ran the full test suite with `Rscript -e "devtools::test(reporter = 'summary')"` and verified other EDA fixture tests passed while failures were limited to the new `run_eda` tests, and `git diff --check` returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a301331e4008326816499b320554208)