### PR TITLE
Document Codecov credential remediation

### DIFF
--- a/future/TODOs.md
+++ b/future/TODOs.md
@@ -35,6 +35,45 @@
 ### Priority 1
 
 - [ ] full git scrub
+- [ ] Remediate the historical Codecov upload-token disclosure:
+    - Problem: A redacted all-history secret scan found a token-shaped Codecov credential in the deleted `codecov.yml`. Commit `b22f919904317f2d3f27584412ccec02464c7d1c` is an affected historical landmark; commit `13815543bc81f5a16ad40f7c3426cfe40f36738e` removed the plaintext configuration and `78dcd5d53a8b2fa9916b93df4bef5258732b4236` later deleted the file. Deleting the current file did not remove the value from Git history. Never copy the credential into this task, an issue, a PR, chat, terminal output or a remediation report.
+    - Goal: Make the historical credential unusable, verify that coverage upload still works securely, assess its exposure, and make an explicit owner-approved decision about whether destructive history rewriting is warranted.
+    - User need: A safe walkthrough that separates urgent credential containment from optional history cleanup and leaves evidence that does not disclose the credential.
+    - Proposed scope:
+        - Phase 1 — contain first:
+            - [ ] Sign in to Codecov with admin access to `antoniojbt/episcout`; confirm whether the displayed upload credential is repository-scoped or inherited from an account/organisation global token. Do not reveal or record its value.
+            - [ ] Treat the historical value as compromised even if it appears old or inactive. Use Codecov's current rotate/regenerate/invalidate control for the applicable token; if no self-service invalidation is available, ask Codecov Support to invalidate it before doing anything to Git history.
+            - [ ] In GitHub, open repository or organisation `Settings` -> `Secrets and variables` -> `Actions`. Replace `CODECOV_TOKEN` with the newly issued value, or deliberately remove it only if the owner chooses Codecov's supported tokenless mode for this public repository. Never include the `CODECOV_TOKEN=` prefix in the stored value.
+            - [ ] Prefer retaining token authentication unless the owner explicitly accepts the weaker protection against false uploads to protected branches. The current workflow uses `codecov/codecov-action@v7`, which supports Codecov's public-repository tokenless setting, but tokenless operation is a policy choice rather than the default remediation.
+            - [ ] After the secret is updated, merge or run a controlled change that causes `.github/workflows/test-coverage.yaml` to execute on a protected `master` push. Confirm the upload step succeeds and the matching commit appears in Codecov; a fork pull-request run alone does not prove that the protected repository secret works.
+            - [ ] Record only the revocation/rotation date, token scope, responsible owner and successful workflow-run URL. Do not record either old or new token values.
+        - Phase 2 — assess exposure with redacted tools:
+            - [ ] Install or update Gitleaks, then run `gitleaks git --redact --log-opts="--all"` and save only a redacted report outside the repository. Also inspect GitHub secret-scanning alerts if that feature is available.
+            - [ ] Confirm the first and last affected commits, branches, tags and file paths instead of assuming the landmark commits above describe every affected ref.
+            - [ ] Inventory forks, open pull requests, release/tag references, Actions artifacts and known clones that may retain the historical objects. Assume public clones cannot be recalled.
+            - [ ] Check Codecov and GitHub audit information available to the owner for unexpected configuration changes or uploads. Record the limits of available audit history; absence of logs is not proof the token was never used.
+        - Phase 3 — make the history decision before rewriting anything:
+            - [ ] Read Codecov's current token guidance at <https://docs.codecov.com/docs/codecov-tokens> and GitHub's sensitive-data-removal guidance at <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository>.
+            - [ ] Decide with the repository owner whether revocation is sufficient. GitHub recommends revoke/rotate first and notes that this may fully mitigate a revocable secret; history rewriting has significant coordination and recontamination risks.
+            - [ ] If revocation is accepted as sufficient, document that decision and skip the remaining rewrite steps. Continue to the verification and prevention phase.
+            - [ ] If history removal is still required, create and approve spec `011-codecov-credential-history-remediation` before running any rewrite. Schedule a maintenance window, pause pushes, merge or close open PRs, notify collaborators and fork owners, and make a recoverable mirror backup with restricted access.
+        - Phase 4 — only if the separately approved spec authorises a rewrite:
+            - [ ] Use a fresh mirror clone and `git-filter-repo` version 2.47 or later with `--sensitive-data-removal`. Prefer removing `codecov.yml` from all affected refs with `--invert-paths --path codecov.yml`; use `--replace-text` only if preserving its non-secret history is important and the replacement file can be handled outside the repository without displaying the credential.
+            - [ ] Inspect `.git/filter-repo/changed-refs`, especially affected pull-request refs and the reported first changed commits. Stop if the affected scope is larger than the approved plan.
+            - [ ] Run the full redacted secret scan and repository tests against the rewritten mirror before changing GitHub. Verify branches, tags, release ancestry and the current workflow configuration.
+            - [ ] Temporarily adjust branch protection only as authorised, force-push the approved rewritten mirror, then immediately restore protection. Do not treat a successful force-push as complete removal.
+            - [ ] Contact GitHub Support with the repository name, affected pull-request count, first changed commits and any reported orphaned LFS objects so cached views and server-side PR references can be purged where eligible.
+            - [ ] Require collaborators to re-clone or follow `git-filter-repo` cleanup instructions; they must rebase, not merge, old branches. Coordinate separately with fork owners because GitHub cannot remove objects from their forks.
+        - Phase 5 — verify and prevent recurrence:
+            - [ ] Confirm `.github/workflows/test-coverage.yaml` obtains any token only from `${{ secrets.CODECOV_TOKEN }}` and that no plaintext credential exists in the current tree, workflow logs, artifacts or rebuilt history.
+            - [ ] Re-run `gitleaks git --redact --log-opts="--all"` from a fresh clone and archive only the redacted result and scanner version outside the repository.
+            - [ ] Verify a protected-branch Codecov upload and the expected required/optional status behaviour without printing secrets.
+            - [ ] Enable or review GitHub secret scanning and push protection where available. Consider a separate, narrowly scoped task to add a pinned secret-scanning check to local/CI workflows.
+            - [ ] Close any GitHub secret-scanning alert only after recording the revocation evidence and the owner-approved history decision. Update this TODO and `future/changelog.md` without including credential material.
+    - Out of scope: Changing coverage thresholds or investigating a coverage-percentage decrease; those remain separate from credential remediation. No history rewrite, force-push, tokenless-policy change or release operation is authorised by this TODO alone.
+    - Candidate files: `future/TODOs.md`, a future `future/specs/011-codecov-credential-history-remediation/`, `.github/workflows/test-coverage.yaml`, GitHub Actions secrets/settings and Codecov repository/account settings. Historical `codecov.yml` is evidence, not a file to restore.
+    - Risks: Exposing the value while investigating it; rotating the wrong global token and breaking other repositories; accepting tokenless uploads without understanding protected-branch integrity; invalidating coverage unexpectedly; rewriting signed commits/tags and PR diffs; losing collaborator work; leaving cached/forked copies; or recontaminating cleaned history from an old clone.
+    - Suggested spec ID: `011-codecov-credential-history-remediation` if history rewriting or workflow/security-policy changes are chosen. Rotation and verification should happen before that spec because containment must not wait for planning.
 - [ ] update 'future/': specs are not marked clearly if done or not, when done move to a 'done' dir; update this TODOs file. Same for 'reviews/'.
 - [ ] See two md files with plans/instructions from prior codex threads, saved in `future/scratch`:
   - [ ] 1-Review applicable agent checklists


### PR DESCRIPTION
## What changed

- add a Priority 1 task for the historical Codecov upload-token disclosure
- provide an ordered walkthrough for containment, exposure assessment, the owner-approved history decision, optional history rewriting, and final verification
- identify safe historical landmarks without reproducing the credential
- link current Codecov and GitHub remediation guidance

## Why

The credential is absent from the current tree but remains in historical Git objects. A future remediation needs to revoke or rotate it before considering a destructive history rewrite, and must avoid redisclosing it during investigation.

## Safety and scope

This PR performs no credential rotation, settings change, history rewrite, force-push, coverage-policy change, or Codecov modification. The TODO explicitly requires separate specification and approval before any history rewrite.

## Validation

- confirmed the historical landmark commits using token-pattern counts without printing the value
- `git diff --check` passes
- documentation-only change; package tests were not rerun
