### PR TITLE
[Docs] Add database-to-report walkthrough

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Development version
 
+- Added a runnable database-to-report walkthrough with a neutral longitudinal CSV fixture. The commented R script demonstrates duplicate review, PostgreSQL inventory and dictionaries, stable pseudonymisation, aggregate-only database EDA, plots, Table 1 and HTML report output without embedding credentials.
 - Added PostgreSQL 17-backed specification-first EDA through `epi_eda_postgres_source()` and `epi_eda_db_run()`, with read-only repeatable-read snapshots, aggregate-only canonical profiling, explicit identifier QA, bounded compact plot data, redacted source display, deterministic SVG paths and manifest-owned staged bundle publication. Ordinary data-frame interfaces and the six summary components remain unchanged; text plots now show character lengths and explicit identifier roles produce no value-bearing summary or plot.
 - Made local datetime preparation deterministic across supported platforms by classifying and converting wall times with `clock`'s packaged IANA timezone data. Ambiguous, nonexistent and unsupported local times block with value-free guidance; this raises the minimum supported R version to 4.0.
 - Added a generic, audit-first PostgreSQL longitudinal pseudonymisation workflow with value-free linkage metadata, a stable restricted identity registry, exact reviewed crosswalks, explicit longitudinal duplicate handling, atomic output writes and a dedicated first-time-user guide. Pseudonymised outputs remain restricted personal data and are not anonymous or automatically disclosure-controlled.

--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -12,6 +12,7 @@ This map identifies the current `episcout` implementation, its user-facing entry
 | PostgreSQL-backed specification-first EDA | `epi_eda_postgres_source()`, the four direct EDA profilers, `epi_eda_db_run()` | `R/eda_postgres_source.R`, `R/eda_postgres_queries.R`, `R/eda_db_run.R`, shared EDA modules | `tests/testthat/test-eda-postgres-*.R` plus data-frame EDA regressions | `README.md`, `vignettes/specification-first-eda.Rmd`, function help |
 | PostgreSQL inventory and dictionaries | `epi_db_inventory()`, `epi_eda_dictionary_scaffold()`, `epi_eda_dictionary_validate()` | `R/db_inventory.R`, `R/eda_dictionary.R` | Database inventory and dictionary tests under `tests/testthat/` | Function help and both workflow vignettes |
 | Longitudinal PostgreSQL pseudonymisation | `epi_sec_linkage_scaffold()`, `epi_sec_linkage_spec()`, `epi_sec_identity_registry_init()`, `epi_sec_pseudonymise_db()` | `R/epi_sec_linkage.R`, `R/epi_sec_registry.R`, `R/epi_sec_pseudonymise_db.R` | `tests/testthat/test-sec-linkage.R`, `tests/testthat/test-sec-pseudonymise-postgres.R` | `vignettes/longitudinal-pseudonymisation.Rmd` |
+| Synthetic database-to-report walkthrough | Inventory, dictionary, duplicate, pseudonymisation, PostgreSQL EDA, Table 1 and report entry points | Installed script and fixtures under `inst/examples/db-to-report/` | Component PostgreSQL and report tests listed above; complete script verified manually | `inst/examples/db-to-report/README.md`, `inst/examples/db-to-report/walkthrough.R` |
 | Starter EDA project | `epi_eda_create_project()` | `R/use_episcout_project.R`, `inst/project-template/` | `tests/testthat/test-project-template.R` | `inst/project-template/README.md` |
 | Lower-level cleaning, statistics, plotting and utilities | `epi_clean_*`, `epi_stats_*`, `epi_plot_*`, `epi_utils_*` | Prefix-matched files under `R/` | Prefix-matched tests under `tests/testthat/` | `README.md`, generated help under `man/` |
 
@@ -24,7 +25,7 @@ Pseudonymisation and descriptive EDA are separate controlled stages. Pseudonymis
 | `R/` | Package source and roxygen documentation; this is the source of truth for generated help. |
 | `tests/testthat/` | Unit, integration, fixture and regression tests. Live PostgreSQL tests are gated by `EPISCOUT_TEST_POSTGRES=1`. |
 | `vignettes/` | Canonical worked guides for specification-first EDA and longitudinal pseudonymisation. |
-| `inst/` | Installed project and report templates. |
+| `inst/` | Installed project and report templates plus runnable worked examples. |
 | `man/` and `NAMESPACE` | Roxygen-generated package interfaces; do not edit them directly. |
 | `data-raw/` | Development scripts and provenance for package or test data. |
 | `scripts/` | Canonical local and CRAN-oriented verification entry points. |

--- a/R/eda_dictionary.R
+++ b/R/eda_dictionary.R
@@ -212,13 +212,13 @@ epi_eda_dictionary_spec <- function(dictionary, table, catalogues = NULL) {
 
 #' Profile approved PostgreSQL catalogue columns
 #'
-#' Return value counts only for active dictionary rows explicitly marked with `profile_catalogue = TRUE`. Direct identifiers, quasi-identifiers, unclassified fields and columns exceeding `max_levels` are rejected before value counts are returned.
+#' Return value counts only for active dictionary rows explicitly marked with `profile_catalogue = TRUE`. Direct identifiers, quasi-identifiers, unclassified fields and columns exceeding `max_levels` are rejected before value counts are returned. The distinct-level limit counts non-missing values; a profiled column containing PostgreSQL `NULL` also returns one `source_value = NA` row with its count.
 #'
 #' @param con An open DBI connection created with RPostgres.
 #' @param dictionary A validated extended dictionary.
 #' @param max_levels Maximum distinct non-missing values allowed for each profiled column.
 #'
-#' @return A data frame containing source keys, `source_value` and `n`.
+#' @return A data frame containing source keys, `source_value` and `n`. `source_value` is `NA` for the optional PostgreSQL `NULL` count row.
 #'
 #' @export
 epi_db_catalogue_profile <- function(con, dictionary, max_levels = 50) {

--- a/R/epi_stats_format.R
+++ b/R/epi_stats_format.R
@@ -1,22 +1,19 @@
-#' @title Format a dataframe with numerical or integer columns
+#' @title Format numeric columns for display
 #'
-#' @description epi_stats_format() formats columns so that digits appear even if they are x.00. Useful for saving a table with descriptive statistics. A data frame with an id column is expected. Check if column is numeric or integer, other types are not formatted. Pass a vector of column number to skip if needed. Values are rounded to the option passed to 'digits' digits = 2 by default
-# format(x, nsmall = digits) is used to ensure xx.00 are printed
-# This may not produce the right results for very large or small numbers
-# Also note that format() will change the class type to factor or character
+#' @description Round and format numeric or integer columns with a fixed minimum number of decimal places. Formatting converts changed columns to character, so use the returned data frame for display rather than further calculation.
 #'
-#' @param df Data.frame with summary to clean up.
-#' @param skip Columns to skip, pass as a string. Default is NULL.
-#' @param digits Number of digits to print. Default is 2.
-#' @param ... Any other parameter that can be passed to round().
+#' @param df Data frame containing columns to format.
+#' @param skip Optional numeric column positions to leave unchanged.
+#' @param digits Number of decimal places to display.
+#' @param ... Additional arguments passed to [format()].
 #'
-#' @return A data.frame with formatted and rounded values.
+#' @return A data frame in which formatted numeric columns are character vectors.
 #'
 #' @author Antonio J Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
 #'
 #' @seealso \code{\link{epi_stats_summary}}, \code{\link{epi_stats_tidy}}, \code{\link{epi_clean_cond_numeric}}, \code{\link[base]{format}}, \code{\link[base]{round}}.
 #'
-#' @example vignettes/summary_funcs_examples.R
+#' @example inst/examples/summary-functions.R
 #'
 #' @export
 #'

--- a/R/epi_stats_summary.R
+++ b/R/epi_stats_summary.R
@@ -1,22 +1,22 @@
 #' @title Get summary statistics from a data frame with multiple columns
 #'
-#' @description epi_stats_summary() provides summary descriptive statistics for columns belonging to either character and factor (class_type = 'chr_fct') or integer and numeric (class_type = 'int_num') while discarding values provided (codes). This is useful if data frame has contingency codes. Columns are ordered according to order in contingency codes option. Rows are then ordered in decreasing order according to column provided.
+#' @description Summarise character/factor or integer/numeric columns while counting or excluding reviewed code values. Set `output = "typed"` to return the canonical six-component descriptive contract for every supported column.
 #'
 #' @param df Data frame
-#' @param codes Specify codes to summarise or exclude as string. Default is NULL.
-#' @param class_type Class of variables to summarise, 'chr_fct' or 'int_num'. Default is character and factor.
-#' @param action Values to summarise, 'codes_only' or 'exclude'. Default is 'exclude'.
+#' @param codes Character vector of values to count or exclude. With typed output, these values are treated as global sentinel-missing codes.
+#' @param class_type Current-output variable class: `"chr_fct"` or `"int_num"`. Leave the default when requesting typed output.
+#' @param action Current-output handling of `codes`: `"codes_only"` or `"exclude"`. Typed output requires `"exclude"`.
 #' @param output Output contract. `"current"` preserves the existing class/action-specific tibble. `"typed"` returns complete typed summary components for every supported column and treats `codes` as global sentinel-missing values.
 #'
 #' @return With `output = "current"`, a tibble using the historical mode-specific schema. With `output = "typed"`, a list containing `variables`, `numeric`, `categorical`, `text`, `temporal` and `skipped` data frames.
 #'
-#' @note Desgined with data frames that require pre-processing and likely have contingency and database codes. Action 'exclude' excludes the string values provided from the summary. Useful to quickly assess what a data.frame contains, types of values in each column and summary statistics if excluding codes.
+#' @note The current output is a historical convenience interface for data frames containing contingency or database codes. Prefer typed output for complete variable coverage and explicit missingness semantics.
 #'
 #' @author Antonio J Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
 #'
 #' @seealso \code{\link{epi_stats_numeric}}, \code{\link{epi_stats_format}}, \code{\link{epi_stats_tidy}}, \code{\link{epi_clean_cond_chr_fct}}, \code{\link{epi_clean_cond_numeric}}.
 #'
-#' @example vignettes/summary_funcs_examples.R
+#' @example inst/examples/summary-functions.R
 #'
 #' @export
 #'

--- a/R/epi_stats_tidy.R
+++ b/R/epi_stats_tidy.R
@@ -1,23 +1,22 @@
-#' @title Tidy up a data.frame with summary values
+#' @title Tidy a count summary
 #'
-#' @description epi_stats_tidy() cleans up the output from epi_stats_summary() and epi_stats_numeric(). Values are rounded to digits (default is 2). format(x, nsmall = digits) is used to ensure xx.00 are printed. Ordering uses as.numeric(as.character(x)) as 'percent' or other numeric column is assumed to be the preferred option. 'decreasing' is passed to order.
+#' @description Convert the historical count output from [epi_stats_summary()] to a wide table, add row totals and percentages, and order rows by a selected numeric column.
 #'
-#' @param sum_df Data.frame with summary to clean up.
-#' @param order_by Column to order results by. Default is 'percent'.
-#' @param perc_n Number of rows from original dataframe to calculate percentage. Must be passed manually.
-#' @param digits = 2,
-#' @param decreasing Sort values by decreasing order. Default is TRUE.
+#' @param sum_df Historical count summary returned by [epi_stats_summary()].
+#' @param order_by Column used to order results. Default is `"percent"`.
+#' @param perc_n Explicit denominator used to calculate percentages.
+#' @param digits Retained historical argument; the current implementation does not format or round values. Use [epi_stats_format()] for display formatting.
+#' @param decreasing Whether to sort `order_by` in decreasing order.
 #'
-#' @return Returns a dataframe as a tibble with values ordered and spread. Adds row sums and percentage.
+#' @return A wide tibble with `row_sums` and `percent` columns, ordered by `order_by`.
 #'
-#' @note Note that format() will likely change the class type.
-# Assumes that the first column is 'id'
+#' @note The first output column is treated as the row identifier when calculating row totals. `perc_n` must match the intended denominator; the function does not infer the analysis population.
 #'
 #' @author Antonio J Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
 #'
 #' @seealso \code{\link{epi_stats_summary}}, \code{\link{epi_stats_format}}, \code{\link{epi_stats_numeric}}.
 #'
-#' @example vignettes/summary_funcs_examples.R
+#' @example inst/examples/summary-functions.R
 #'
 #' @export
 #'

--- a/R/epi_write_df.R
+++ b/R/epi_write_df.R
@@ -1,11 +1,11 @@
 #' Save a Data Frame to a File with Custom Formatting
 #'
-#' This function constructs a file path using a specified subdirectory, file name, and suffix, then writes a data frame to that file. It is designed for flexibility in saving results with standardized naming conventions.
+#' This function constructs a file path using a specified subdirectory, file name and suffix, then calls [epi_write()]. The suffix changes only the filename; output remains tab-separated unless `epi_write()` is called directly with another `sep` value.
 #'
 #' @param df A data frame to be written to the file.
 #' @param results_subdir A character string specifying the directory where the file will be saved.
 #' @param file_n A character string specifying the base name of the file (without the suffix).
-#' @param suffix A character string specifying the file extension (e.g., "txt", "csv").
+#' @param suffix A character string specifying the filename extension. Use `"tsv"` for the default tab-separated output.
 #'
 #' @return The full file path of the saved file. Prints a message indicating the file's location.
 #'
@@ -14,7 +14,7 @@
 #' # Example usage
 #' results_subdir <- "output"
 #' file_n <- "desc_dates"
-#' suffix <- "txt"
+#' suffix <- "tsv"
 #' epi_write_df(sum_dates_df, results_subdir, file_n, suffix)
 #' }
 #'

--- a/R/episcout-package.R
+++ b/R/episcout-package.R
@@ -2,7 +2,7 @@
 #'
 #' @description Helpers for cleaning, exploring and visualising data, including specification-first EDA and an audit-first PostgreSQL workflow for stable longitudinal pseudonymisation.
 #'
-#' @details Start with `vignette("introduction_episcout")` for package helpers, `vignette("specification-first-eda")` for reviewed EDA, or `vignette("longitudinal-pseudonymisation")` for one stable pseudonymous identity across related PostgreSQL tables. The longitudinal guide covers database prerequisites, value-free linkage metadata, read-only audits, blockers, apply, recovery and EDA handoff.
+#' @details Start with `vignette("introduction_episcout")` for package helpers, `vignette("specification-first-eda")` for reviewed EDA, or `vignette("longitudinal-pseudonymisation")` for one stable pseudonymous identity across related PostgreSQL tables. The longitudinal guide covers database prerequisites, value-free linkage metadata, read-only audits, blockers, apply, recovery and EDA handoff. The installed `examples/db-to-report/walkthrough.R` script provides a complete interactive synthetic exercise from duplicate review and database setup through pseudonymisation, EDA, Table 1 and HTML report output.
 #'
 #' Pseudonymised data remain restricted personal data. They are not anonymous or automatically disclosure-controlled.
 #'

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ install.packages("episcout")
 --->
 
 Install from GitHub:
+
 ``` r
 install.packages("devtools")
-library(devtools)
-install_github("AntonioJBT/episcout")
+devtools::install_github("AntonioJBT/episcout")
 ```
 
 ## Development
@@ -67,11 +67,13 @@ CRAN does not require `renv`; it requires a source tarball from `R CMD build` th
 
 ## Getting Started
 
-There are two main ways to use episcout:
+There are three main ways to use episcout:
 
 * Use lower-level helpers directly: `epi_clean_*`, `epi_stats_*`, `epi_plot_*` and `epi_utils_*`.
 * Use the review-gated new-dataset workflow through `epi_eda_intake_run()`, or compose the lower-level specification-first functions directly.
 * For related restricted PostgreSQL tables, follow the [audit-first longitudinal pseudonymisation guide](vignettes/longitudinal-pseudonymisation.Rmd) to create value-free linkage metadata, initialise a stable registry and inspect blockers before any write.
+
+For a complete runnable learning path, use the [database-to-report walkthrough](inst/examples/db-to-report/README.md). Its commented R script starts with a duplicated synthetic longitudinal CSV, creates disposable PostgreSQL relations, pseudonymises them, runs database-backed EDA and finishes with plots, a Table 1 and an HTML report.
 
 Pseudonymised data remain restricted personal data. They are not anonymous or automatically disclosure-controlled. The guide explains database-administrator prerequisites, duplicate handling, recovery and the reviewed handoff into EDA.
 
@@ -140,9 +142,12 @@ death,Death during follow-up,binary,outcome,,"0;1",0,1,,TRUE,outcomes,Outcome in
 
 The optional `missing_codes` column accepts semicolon-separated sentinel values such as `Unknown;Refused`. These values are counted as missing in `epi_eda_profile_missing()` and excluded from observed EDA summaries and plots. Schema output reports presence in `status` and separately reports descriptive type compatibility in `type_status` and `type_reason`; it does not coerce data. The canonical summary contract covers numeric, integer, categorical, binary, text, date and datetime variables, with explicit variable coverage and documented skips.
 
-After reviewing the dictionary, inspect the preparation plan before changing the received data. Apply is all-or-nothing: a missing required variable, unsafe conversion or unexpected level returns the original data and a complete blocking audit.
+After saving and reviewing the dictionary, load it with its matching data and inspect the preparation plan before changing anything. Apply is all-or-nothing: a missing required variable, unsafe conversion or unexpected level returns the original data and a complete blocking audit.
 
 ``` r
+spec <- epi_eda_spec("metadata/data_dictionary.csv")
+data <- read.csv("data/input.csv", stringsAsFactors = FALSE)
+
 assessment <- epi_eda_prepare(data, spec, mode = "audit")
 assessment$audit
 
@@ -153,10 +158,10 @@ prepared$data
 
 Character numeric parsing is not implicit, categorical levels come from the reviewed specification, and local character datetimes require a reviewed `timezone`. Empty or whitespace-only sentinels cannot be represented by the current semicolon-delimited `missing_codes` format. The preparation core is in memory and does not write row-level data. It does not identify personal information or anonymise data; pseudonymisation remains a separate controlled step.
 
-Summarize a prepared cohort overall and by one reviewed categorical or binary variable, then create a traceable long-form Table 1:
+Summarise a prepared cohort overall and by one reviewed categorical or binary variable, then create a traceable long-form Table 1:
 
 ``` r
-stratified <- epi_eda_profile_stratified(prepared$data, spec, strata = "study_group")
+stratified <- epi_eda_profile_stratified(prepared$data, spec, strata = "sex")
 stratified$groups
 stratified$numeric
 
@@ -275,11 +280,11 @@ Each direct profiler owns one read-only repeatable-read transaction. `epi_eda_db
 
 The bundle is aggregate-only, not anonymous or disclosure-controlled. Complete categorical frequencies, identifier QA, plots, variable and relation names, declared levels and missing sentinels may be sensitive. The normalized caller-authored specification is deliberately written for review, so its declared values are not covered by the raw-observation exclusion. Review every artifact before sharing. episcout does not control PostgreSQL, RPostgres, administrator, backup or server logging. Unsupported storage, especially `timestamp without time zone`, requires a caller-reviewed view cast; episcout does not infer local-time or DST meaning.
 
-Render the optional HTML report when `rmarkdown` is installed:
+The aggregate PostgreSQL bundle is the end of the server-backed workflow. `epi_eda_render_report()` currently accepts an in-memory data frame, not a PostgreSQL source or aggregate bundle. Render its optional HTML report only for an approved in-memory dataset when `rmarkdown` and Pandoc are installed:
 
 ``` r
 epi_eda_render_report(
-  data = data,
+  data = prepared$data,
   spec = spec,
   output_dir = "outputs"
 )

--- a/inst/examples/db-to-report/README.md
+++ b/inst/examples/db-to-report/README.md
@@ -1,0 +1,43 @@
+# Database-to-report walkthrough
+
+This installed example is a step-by-step R script for a disposable PostgreSQL 17 database. It starts with a deliberately duplicated synthetic longitudinal CSV, creates related PostgreSQL source tables, reviews database metadata, pseudonymises both tables through one stable identity registry, runs aggregate-only PostgreSQL EDA, and finishes with plots, a long-form Table 1 and an HTML report.
+
+The files are:
+
+- `walkthrough.R`: the interactive, commented workflow;
+- `synthetic-longitudinal.csv`: neutral synthetic input with one intentional exact duplicate visit row.
+
+The data are synthetic and exist only to teach and test the workflow. They are not suitable for inference, privacy protection or disclosure-control validation.
+
+## Prerequisites
+
+Use a disposable PostgreSQL 17 or later database in which your approved learning role may create schemas and tables. The script never creates a PostgreSQL server, login role or credential. A database administrator should provide those infrastructure prerequisites; for a local disposable installation this may be as simple as creating an empty database named `episcout_walkthrough`.
+
+Set standard libpq environment variables before opening R. Do not place a password in the script or commit it to source control.
+
+```bash
+export PGHOST=127.0.0.1
+export PGPORT=5432
+export PGDATABASE=episcout_walkthrough
+export PGUSER=your_learning_role
+# Use an approved password store or a temporary PGPASSWORD only when required.
+```
+
+Install the suggested packages used by the walkthrough: `RPostgres`, `data.table`, `compare`, `ggplot2`, `rmarkdown` and their dependencies. The HTML step also requires Pandoc 1.12.3 or later; `rmarkdown::pandoc_available()` should return `TRUE` before the database work begins.
+
+## Run it
+
+Locate the installed example, open it in an editor, and run one numbered section at a time in an interactive R session:
+
+```r
+example_dir <- system.file("examples", "db-to-report", package = "episcout")
+file.edit(file.path(example_dir, "walkthrough.R"))
+```
+
+For a repository checkout, open `inst/examples/db-to-report/walkthrough.R` directly. The script creates three uniquely named schemas, so it does not overwrite a previous run. It prints the schema names and output directory near the end.
+
+Set `EPISCOUT_WALKTHROUGH_CLEANUP=1` before running only when the disposable schemas should be removed automatically after the outputs have been inspected. Cleanup drops the three uniquely named walkthrough schemas with `CASCADE`; it never targets a fixed production name.
+
+## Privacy boundary
+
+The final row-level extraction and HTML report are appropriate here only because every row is explicitly synthetic. For real restricted data, use the aggregate-only `epi_eda_db_run()` bundle by default and obtain separate approval before extracting pseudonymised rows. Pseudonymised data remain restricted personal data; they are not anonymous or automatically safe to share.

--- a/inst/examples/db-to-report/synthetic-longitudinal.csv
+++ b/inst/examples/db-to-report/synthetic-longitudinal.csv
@@ -1,0 +1,12 @@
+source_person_id,sex,cohort_group,baseline_age,visit_number,visit_date,systolic_bp,outcome,symptom_text,site
+PX001,Female,Intervention,45,1,2025-01-10,118,0,None,North
+PX001,Female,Intervention,45,2,2025-04-11,116,0,Mild fatigue,North
+PX001,Female,Intervention,45,3,2025-07-10,114,0,None,North
+PX002,Male,Comparator,52,1,2025-01-12,132,0,Headache,South
+PX002,Male,Comparator,52,2,2025-04-14,136,1,Headache,South
+PX002,Male,Comparator,52,2,2025-04-14,136,1,Headache,South
+PX003,Not recorded,Intervention,61,1,2025-01-15,145,0,Not recorded,Central
+PX003,Not recorded,Intervention,61,2,2025-04-16,,0,Not recorded,Central
+PX004,Female,Comparator,38,1,2025-01-18,109,0,None,North
+PX004,Female,Comparator,38,2,2025-04-20,111,0,None,North
+PX005,Male,Intervention,67,1,2025-01-22,151,1,Dizziness,South

--- a/inst/examples/db-to-report/walkthrough.R
+++ b/inst/examples/db-to-report/walkthrough.R
@@ -1,0 +1,519 @@
+# episcout: synthetic longitudinal data from PostgreSQL to an HTML report
+#
+# Run this file one numbered section at a time in an interactive R session.
+# The example uses only neutral synthetic records. Do not copy its privacy classifications or extraction step to real data without qualified review.
+
+# 1. Load packages and locate the installed example ---------------------------
+
+library(episcout)
+
+required_packages <- c(
+  "DBI", "RPostgres", "data.table", "ggplot2", "rmarkdown"
+)
+missing_packages <- required_packages[
+  !vapply(required_packages, requireNamespace, logical(1), quietly = TRUE)
+]
+if (length(missing_packages) > 0L) {
+  stop(
+    "Install the walkthrough packages first: ",
+    paste(missing_packages, collapse = ", "),
+    call. = FALSE
+  )
+}
+if (!rmarkdown::pandoc_available(version = "1.12.3")) {
+  stop(
+    "Install Pandoc 1.12.3 or later before starting the walkthrough.",
+    call. = FALSE
+  )
+}
+
+example_dir <- system.file(
+  "examples", "db-to-report",
+  package = "episcout"
+)
+if (!nzchar(example_dir)) {
+  example_dir <- file.path("inst", "examples", "db-to-report")
+}
+if (!dir.exists(example_dir)) {
+  stop("Run from the episcout repository or an installed package.", call. = FALSE)
+}
+
+csv_path <- file.path(example_dir, "synthetic-longitudinal.csv")
+walkthrough_data <- epi_read(csv_path)
+walkthrough_data$visit_date <- as.Date(walkthrough_data$visit_date)
+
+dim(walkthrough_data)
+epi_head_and_tail(walkthrough_data, rows = 3, cols = 6)
+
+# 2. Check the intentional duplicate before loading PostgreSQL ----------------
+
+# A person can correctly have several longitudinal visits. The reviewed record key is person plus visit number, so inspect repeated values of that key.
+walkthrough_data$visit_key <- paste(
+  walkthrough_data$source_person_id,
+  walkthrough_data$visit_number,
+  sep = "::"
+)
+duplicate_visits <- epi_clean_get_dups(
+  walkthrough_data,
+  var = "visit_key",
+  freq = 1
+)
+duplicate_visits
+
+# compare is suggested rather than required. When installed, this confirms that the two PX002 visit-2 rows have no differing columns.
+if (requireNamespace("compare", quietly = TRUE)) {
+  duplicate_comparison <- epi_clean_compare_dup_rows(
+    duplicate_visits,
+    val_id = "PX002::2",
+    col_id = "visit_key"
+  )
+  duplicate_comparison
+}
+
+# The source owner confirms this pair is an accidental exact duplicate. Remove only exact whole-row copies; never choose a winner between conflicting rows.
+source_columns <- setdiff(names(walkthrough_data), "visit_key")
+exact_duplicate <- duplicated(walkthrough_data[source_columns])
+clean_longitudinal <- walkthrough_data[!exact_duplicate, source_columns]
+stopifnot(sum(exact_duplicate) == 1L)
+stopifnot(!anyDuplicated(clean_longitudinal[c(
+  "source_person_id", "visit_number"
+)]))
+
+# Separate person-grain and visit-grain relations. The consistency assertion is important: one person must not have conflicting baseline attributes.
+person_columns <- c(
+  "source_person_id", "sex", "cohort_group", "baseline_age"
+)
+participants <- unique(clean_longitudinal[person_columns])
+stopifnot(!anyDuplicated(participants$source_person_id))
+
+visits <- clean_longitudinal[c(
+  "source_person_id", "cohort_group", "visit_number", "visit_date",
+  "systolic_bp", "outcome", "symptom_text", "site"
+)]
+
+# 3. Connect to an approved disposable PostgreSQL database --------------------
+
+# Configure PGHOST, PGPORT, PGDATABASE and PGUSER outside this script. Use an approved password store; PGPASSWORD is passed only when it already exists.
+connection_arguments <- list(
+  drv = RPostgres::Postgres(),
+  host = Sys.getenv("PGHOST", unset = "127.0.0.1"),
+  port = as.integer(Sys.getenv("PGPORT", unset = "5432")),
+  dbname = Sys.getenv("PGDATABASE", unset = "episcout_walkthrough"),
+  user = Sys.getenv("PGUSER", unset = Sys.info()[["user"]])
+)
+pg_password <- Sys.getenv("PGPASSWORD", unset = "")
+if (nzchar(pg_password)) {
+  connection_arguments$password <- pg_password
+}
+
+con <- do.call(DBI::dbConnect, connection_arguments)
+DBI::dbIsValid(con)
+
+# If you stop before the final section, close this session with DBI::dbDisconnect(con). The generated schemas are uniquely named and are not overwritten.
+
+# Use unique schema names so a rerun cannot overwrite earlier walkthrough data.
+run_id <- Sys.getenv(
+  "EPISCOUT_WALKTHROUGH_RUN_ID",
+  unset = paste0(format(Sys.time(), "%y%m%d%H%M%S"), Sys.getpid())
+)
+if (!grepl("^[a-z0-9]{6,20}$", run_id)) {
+  DBI::dbDisconnect(con)
+  stop(
+    "EPISCOUT_WALKTHROUGH_RUN_ID must contain 6 to 20 lower-case letters or digits.",
+    call. = FALSE
+  )
+}
+
+source_schema <- paste0("episcout_walk_source_", run_id)
+registry_schema <- paste0("episcout_walk_registry_", run_id)
+output_schema <- paste0("episcout_walk_output_", run_id)
+walkthrough_schemas <- c(source_schema, registry_schema, output_schema)
+
+for (schema in walkthrough_schemas) {
+  quoted_schema <- as.character(DBI::dbQuoteIdentifier(con, schema))
+  DBI::dbExecute(con, paste("CREATE SCHEMA", quoted_schema))
+  DBI::dbExecute(
+    con,
+    paste("REVOKE ALL ON SCHEMA", quoted_schema, "FROM PUBLIC")
+  )
+}
+
+# Load the reviewed, deduplicated synthetic relations. Source identifiers stay in PostgreSQL after this point in the worked database workflow.
+DBI::dbWriteTable(
+  con,
+  DBI::Id(schema = source_schema, table = "participants"),
+  participants
+)
+DBI::dbWriteTable(
+  con,
+  DBI::Id(schema = source_schema, table = "visits"),
+  visits
+)
+
+# 4. Inventory the database and review a reusable dictionary ------------------
+
+inventory <- epi_db_inventory(
+  con,
+  schema = source_schema,
+  tables = c("participants", "visits"),
+  row_counts = "exact"
+)
+inventory$tables
+inventory$columns
+inventory$constraints
+
+dictionary <- epi_eda_dictionary_scaffold(inventory)
+
+# These decisions are valid only for the documented synthetic fixture. For real sources, a qualified reviewer must decide every semantic and privacy field.
+dictionary$provenance <- "reviewed_synthetic_walkthrough_v1"
+dictionary$validation_status <- "confirmed"
+
+labels <- c(
+  source_person_id = "Source person identifier",
+  sex = "Recorded sex",
+  cohort_group = "Cohort group",
+  baseline_age = "Age at baseline",
+  visit_number = "Visit number",
+  visit_date = "Visit date",
+  systolic_bp = "Systolic blood pressure",
+  outcome = "Illustrative binary outcome",
+  symptom_text = "Synthetic symptom note",
+  site = "Collection site"
+)
+types <- c(
+  source_person_id = "text",
+  sex = "categorical",
+  cohort_group = "categorical",
+  baseline_age = "integer",
+  visit_number = "integer",
+  visit_date = "date",
+  systolic_bp = "numeric",
+  outcome = "binary",
+  symptom_text = "text",
+  site = "categorical"
+)
+roles <- c(
+  source_person_id = "identifier",
+  sex = "covariate",
+  cohort_group = "exposure",
+  baseline_age = "covariate",
+  visit_number = "time",
+  visit_date = "time",
+  systolic_bp = "outcome",
+  outcome = "outcome",
+  symptom_text = "outcome",
+  site = "covariate"
+)
+
+dictionary$label <- unname(labels[dictionary$source_column])
+dictionary$type <- unname(types[dictionary$source_column])
+dictionary$role <- unname(roles[dictionary$source_column])
+dictionary$description <- paste(
+  dictionary$label,
+  "in the neutral synthetic walkthrough."
+)
+dictionary$required <- !dictionary$source_column %in% c(
+  "sex", "systolic_bp", "symptom_text"
+)
+dictionary$units[dictionary$source_column == "baseline_age"] <- "years"
+dictionary$units[dictionary$source_column == "systolic_bp"] <- "mmHg"
+dictionary$min[dictionary$source_column == "baseline_age"] <- "18"
+dictionary$max[dictionary$source_column == "baseline_age"] <- "110"
+dictionary$min[dictionary$source_column == "systolic_bp"] <- "50"
+dictionary$max[dictionary$source_column == "systolic_bp"] <- "250"
+dictionary$missing_codes[dictionary$source_column == "sex"] <- "Not recorded"
+dictionary$missing_codes[dictionary$source_column == "symptom_text"] <- "Not recorded"
+
+identifier_rows <- dictionary$source_column == "source_person_id"
+quasi_rows <- dictionary$source_column %in% c(
+  "sex", "baseline_age", "visit_date", "site"
+)
+sensitive_rows <- dictionary$source_column %in% c(
+  "systolic_bp", "outcome", "symptom_text"
+)
+
+dictionary$privacy_class <- "non_sensitive"
+dictionary$analytic_action <- "retain"
+dictionary$privacy_class[identifier_rows] <- "direct_identifier"
+dictionary$analytic_action[identifier_rows] <- "bridge"
+dictionary$privacy_class[quasi_rows] <- "quasi_identifier"
+dictionary$analytic_action[quasi_rows] <- "retain_restricted"
+dictionary$privacy_class[sensitive_rows] <- "sensitive"
+dictionary$analytic_action[sensitive_rows] <- "retain_restricted"
+
+dictionary$catalog_name[dictionary$source_column == "sex"] <- "sex"
+dictionary$catalog_name[dictionary$source_column == "cohort_group"] <- "cohort_group"
+dictionary$catalog_name[dictionary$source_column == "outcome"] <- "outcome"
+dictionary$catalog_name[dictionary$source_column == "site"] <- "site"
+
+# Profile only fields approved for value counting in this synthetic database.
+dictionary$profile_catalogue <- dictionary$source_column %in% c(
+  "cohort_group", "outcome"
+)
+catalogue_profile <- epi_db_catalogue_profile(
+  con,
+  dictionary,
+  max_levels = 5L
+)
+catalogue_profile
+
+# Catalogue meaning comes from the known fixture contract, not from guessing at the observed profile. Missingness is explicit for the synthetic sex field.
+catalogues <- data.frame(
+  catalog_name = c(
+    "sex", "sex", "sex",
+    "cohort_group", "cohort_group",
+    "outcome", "outcome",
+    "site", "site", "site"
+  ),
+  source_value = c(
+    "Female", "Male", "Not recorded",
+    "Comparator", "Intervention",
+    "0", "1",
+    "Central", "North", "South"
+  ),
+  label = c(
+    "Female", "Male", "Not recorded",
+    "Comparator", "Intervention",
+    "No outcome", "Outcome",
+    "Central", "North", "South"
+  ),
+  display_order = c(1L, 2L, 3L, 1L, 2L, 1L, 2L, 1L, 2L, 3L),
+  is_missing = c(
+    FALSE, FALSE, TRUE,
+    FALSE, FALSE,
+    FALSE, FALSE,
+    FALSE, FALSE, FALSE
+  ),
+  provenance = "reviewed_synthetic_walkthrough_v1",
+  validation_status = "confirmed",
+  stringsAsFactors = FALSE
+)
+epi_eda_dictionary_validate(dictionary, catalogues)
+
+# 5. Declare longitudinal linkage and initialise the restricted registry ------
+
+linkage_draft <- epi_sec_linkage_scaffold(
+  dictionary,
+  tables = data.frame(
+    source_schema = rep(source_schema, 2L),
+    source_table = c("participants", "visits"),
+    stringsAsFactors = FALSE
+  )
+)
+linkage_draft$tables
+
+linkage_tables <- linkage_draft$tables
+linkage_tables$identity_namespace <- "synthetic_person"
+linkage_tables$can_enrol <- linkage_tables$source_table == "participants"
+linkage_tables$one_row_per_entity <- linkage_tables$source_table == "participants"
+linkage_tables$destination_table <- paste0(
+  linkage_tables$source_table,
+  "_pseudonymised"
+)
+linkage_tables$provenance <- "reviewed_synthetic_walkthrough_v1"
+linkage_tables$validation_status <- "confirmed"
+
+record_keys <- data.frame(
+  source_schema = source_schema,
+  source_table = "visits",
+  key_column = "visit_number",
+  key_order = 1L,
+  stringsAsFactors = FALSE
+)
+linkage <- epi_sec_linkage_spec(
+  tables = linkage_tables,
+  record_keys = record_keys
+)
+
+registry_audit <- epi_sec_identity_registry_init(
+  con,
+  registry_schema = registry_schema,
+  mode = "audit"
+)
+registry_audit
+stopifnot(registry_audit$status == "initialisation_required")
+
+registry_apply <- epi_sec_identity_registry_init(
+  con,
+  registry_schema = registry_schema,
+  token_prefix = "W",
+  n_bytes = 24L,
+  mode = "apply"
+)
+registry_apply
+stopifnot(registry_apply$status == "ready")
+
+# 6. Audit, then explicitly apply, pseudonymisation ----------------------------
+
+pseudonym_audit <- epi_sec_pseudonymise_db(
+  con,
+  dictionary = dictionary,
+  linkage = linkage,
+  registry_schema = registry_schema,
+  output_schema = output_schema,
+  catalogues = catalogues,
+  mode = "audit",
+  exact_duplicates = "report"
+)
+pseudonym_audit
+pseudonym_audit$table_audit
+pseudonym_audit$duplicate_audit
+pseudonym_audit$issues
+stopifnot(pseudonym_audit$status == "audit_complete")
+
+pseudonymised <- epi_sec_pseudonymise_db(
+  con,
+  dictionary = dictionary,
+  linkage = linkage,
+  registry_schema = registry_schema,
+  output_schema = output_schema,
+  catalogues = catalogues,
+  mode = "apply",
+  exact_duplicates = "report",
+  existing = "error"
+)
+pseudonymised
+pseudonymised$table_audit
+pseudonymised$manifest
+stopifnot(pseudonymised$status == "complete")
+stopifnot(all(pseudonymised$table_audit$n_invalid_id == 0))
+stopifnot(all(pseudonymised$table_audit$n_unmatched == 0))
+
+# 7. Hand the pseudonymised visit dictionary into PostgreSQL-backed EDA --------
+
+visits_table <- "visits_pseudonymised"
+visits_spec <- epi_eda_dictionary_spec(
+  pseudonymised$output_dictionary,
+  table = paste(output_schema, visits_table, sep = "."),
+  catalogues = pseudonymised$output_catalogues
+)
+visits_spec
+
+postgres_source <- epi_eda_postgres_source(
+  con,
+  schema = output_schema,
+  relation = visits_table
+)
+postgres_source
+
+schema_profile <- epi_eda_check_schema(postgres_source, visits_spec)
+missing_profile <- epi_eda_profile_missing(postgres_source, visits_spec)
+summary_profile <- epi_eda_profile_summaries(postgres_source, visits_spec)
+plot_profile <- epi_eda_profile_plots(postgres_source, visits_spec)
+
+schema_profile
+missing_profile
+summary_profile$variables
+summary_profile$numeric
+summary_profile$categorical
+plot_profile$systolic_bp
+
+output_root <- Sys.getenv(
+  "EPISCOUT_WALKTHROUGH_OUTPUT",
+  unset = file.path(
+    getwd(),
+    paste0("episcout-walkthrough-output-", run_id)
+  )
+)
+dir.create(output_root, recursive = TRUE, showWarnings = FALSE)
+
+database_bundle <- epi_eda_db_run(
+  postgres_source,
+  visits_spec,
+  output_dir = file.path(output_root, "postgres-eda-bundle"),
+  plots = TRUE,
+  max_plot_levels = 10L
+)
+database_bundle$status
+database_bundle$manifest
+database_bundle$identifier_qa
+
+# 8. Create a Table 1 and report from the explicitly synthetic output ----------
+
+# This row-level extraction is used only because the fixture is entirely synthetic. Real pseudonymised data remain restricted personal data; prefer the aggregate database bundle unless a separate approved extraction is required.
+analysis_visits <- DBI::dbReadTable(
+  con,
+  DBI::Id(schema = output_schema, table = visits_table)
+)
+analysis_visits <- analysis_visits[
+  order(analysis_visits$entity_token, analysis_visits$visit_number), ,
+  drop = FALSE
+]
+
+preparation_audit <- epi_eda_prepare(
+  analysis_visits,
+  visits_spec,
+  mode = "audit"
+)
+preparation_audit$audit
+
+prepared_visits <- epi_eda_prepare(
+  analysis_visits,
+  visits_spec,
+  mode = "apply"
+)
+stopifnot(prepared_visits$metadata$overall_status == "prepared")
+
+stratified <- epi_eda_profile_stratified(
+  prepared_visits$data,
+  visits_spec,
+  strata = "cohort_group"
+)
+table1 <- epi_eda_table1(stratified)
+stratified$groups
+table1
+
+# The lower-level helpers remain useful after the reviewed workflow. Spread the synthetic visits to a wide view and inspect a conventional numeric summary.
+wide_parts <- epi_clean_spread_repeated(
+  prepared_visits$data[c(
+    "entity_token", "visit_number", "systolic_bp", "outcome"
+  )],
+  rep_col = "visit_number",
+  id_col_num = 1L
+)
+wide_visits <- epi_clean_merge_nested_dfs(
+  wide_parts,
+  id_col = "entity_token"
+)
+epi_head_and_tail(wide_visits, rows = 2, cols = 6)
+epi_stats_numeric(prepared_visits$data$systolic_bp)
+
+table_path <- file.path(output_root, "table1.tsv")
+epi_write(table1, table_path)
+
+report_dir <- file.path(output_root, "html-report")
+dir.create(report_dir, showWarnings = FALSE)
+report_path <- epi_eda_render_report(
+  data = prepared_visits$data,
+  spec = visits_spec,
+  output_dir = report_dir,
+  quiet = TRUE
+)
+report_path
+
+# 9. Reconcile outputs, disconnect and optionally remove disposable schemas ----
+
+stopifnot(file.exists(report_path))
+stopifnot(file.exists(table_path))
+stopifnot(database_bundle$metadata$status == "complete")
+
+cat("\nWalkthrough schemas:\n", paste(walkthrough_schemas, collapse = "\n"), "\n")
+cat("\nWalkthrough outputs:\n", normalizePath(output_root), "\n")
+
+cleanup_schemas <- identical(
+  Sys.getenv("EPISCOUT_WALKTHROUGH_CLEANUP", unset = "0"),
+  "1"
+)
+if (cleanup_schemas) {
+  for (schema in rev(walkthrough_schemas)) {
+    quoted_schema <- as.character(DBI::dbQuoteIdentifier(con, schema))
+    DBI::dbExecute(
+      con,
+      paste("DROP SCHEMA", quoted_schema, "CASCADE")
+    )
+  }
+}
+
+DBI::dbDisconnect(con)
+
+cat("\nComplete. Open the HTML report shown above in a web browser.\n")

--- a/inst/examples/summary-functions.R
+++ b/inst/examples/summary-functions.R
@@ -1,0 +1,36 @@
+# Shared examples for the three summary-table helpers.
+
+set.seed(20260805)
+example_data <- data.frame(
+  visit = rep(c("baseline", "follow_up"), 4),
+  group = rep(c("A", "B"), each = 4),
+  score = c(10, 12, 14, 13, 9, 11, 15, 16),
+  outcome = factor(c(0, 0, 1, 0, 0, 1, 1, 1))
+)
+
+# Summarise the character and factor columns after excluding a reviewed code.
+categorical_summary <- epi_stats_summary(
+  example_data,
+  codes = "follow_up",
+  class_type = "chr_fct",
+  action = "exclude"
+)
+categorical_summary
+
+# Convert counts to a display table; retain unformatted values for calculations.
+code_counts <- epi_stats_summary(
+  example_data,
+  codes = c("baseline", "A", "0"),
+  class_type = "chr_fct",
+  action = "codes_only"
+)
+tidy_counts <- epi_stats_tidy(
+  code_counts,
+  perc_n = nrow(example_data)
+)
+epi_stats_format(tidy_counts, digits = 1)
+
+# The typed contract profiles every supported column with explicit coverage.
+typed_summary <- epi_stats_summary(example_data, output = "typed")
+names(typed_summary)
+typed_summary$variables

--- a/inst/project-template/README.md
+++ b/inst/project-template/README.md
@@ -50,6 +50,8 @@ Do not export identifiable PostgreSQL rows merely to use this file-based EDA sca
 
 Pseudonymised outputs still require restricted access and disclosure review. They are not anonymous or automatically disclosure-controlled.
 
+For a runnable synthetic example that connects database inventory, longitudinal pseudonymisation, PostgreSQL-backed EDA and this HTML reporting workflow, see the installed `examples/db-to-report/walkthrough.R` script.
+
 ## Optional targets workflow
 
 If `targets` is installed, run:

--- a/man/epi_clean_add_rep_num.Rd
+++ b/man/epi_clean_add_rep_num.Rd
@@ -53,5 +53,5 @@ df2
 
 }
 \author{
-Antonio Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
+Antonio Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
 }

--- a/man/epi_clean_class_to_factor.Rd
+++ b/man/epi_clean_class_to_factor.Rd
@@ -54,5 +54,5 @@ df_factor
 \code{\link{epi_clean_count_classes}}, \code{\link{epi_clean_cond_date}}, \code{\link{epi_clean_cond_chr_fct}}, \code{\link{epi_clean_cond_numeric}}
 }
 \author{
-Antonio Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
+Antonio Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
 }

--- a/man/epi_clean_cond_date.Rd
+++ b/man/epi_clean_cond_date.Rd
@@ -38,5 +38,5 @@ epi_clean_cond_date(df_date[, "date_col"]) # should be 'TRUE'
 \code{\link{epi_clean_cond_numeric}}, \code{\link{epi_clean_class_to_factor}}, \code{\link{epi_clean_count_classes}}, \code{\link[base]{is.character}}, \code{\link[base]{is.factor}}.
 }
 \author{
-Antonio Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
+Antonio Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
 }

--- a/man/epi_clean_cond_numeric.Rd
+++ b/man/epi_clean_cond_numeric.Rd
@@ -36,5 +36,5 @@ epi_clean_cond_numeric(df[, "x"]) # should be TRUE
 \code{\link{epi_clean_cond_chr_fct}}, \code{\link{epi_clean_cond_date}}, \code{\link{epi_clean_class_to_factor}}, \code{\link{epi_clean_count_classes}}, \code{\link[base]{is.integer}}, \code{\link[base]{is.numeric}}
 }
 \author{
-Antonio Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
+Antonio Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
 }

--- a/man/epi_clean_count_classes.Rd
+++ b/man/epi_clean_count_classes.Rd
@@ -38,5 +38,5 @@ epi_clean_count_classes(df)
 \code{\link{epi_clean_cond_numeric}}, \code{\link{epi_clean_class_to_factor}}, \code{\link{epi_clean_cond_date}}.
 }
 \author{
-Antonio Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
+Antonio Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
 }

--- a/man/epi_clean_get_dups.Rd
+++ b/man/epi_clean_get_dups.Rd
@@ -37,5 +37,5 @@ check_dups
 \code{\link[base]{duplicated}}
 }
 \author{
-Antonio Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
+Antonio Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
 }

--- a/man/epi_clean_replace_value.Rd
+++ b/man/epi_clean_replace_value.Rd
@@ -55,5 +55,5 @@ df_factor$date_col
 \code{\link{epi_clean_add_rep_num}}, \code{\link{epi_clean_add_colname_suffix}}, \code{\link[stringr]{str_detect}}.
 }
 \author{
-Antonio Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
+Antonio Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
 }

--- a/man/epi_clean_spread_repeated.Rd
+++ b/man/epi_clean_spread_repeated.Rd
@@ -42,5 +42,5 @@ df_spread
 \code{\link{epi_clean_add_colname_suffix}}, \code{\link{epi_clean_merge_nested_dfs}}, \code{\link{epi_clean_transpose}}
 }
 \author{
-Antonio Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
+Antonio Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
 }

--- a/man/epi_db_catalogue_profile.Rd
+++ b/man/epi_db_catalogue_profile.Rd
@@ -14,8 +14,8 @@ epi_db_catalogue_profile(con, dictionary, max_levels = 50)
 \item{max_levels}{Maximum distinct non-missing values allowed for each profiled column.}
 }
 \value{
-A data frame containing source keys, \code{source_value} and \code{n}.
+A data frame containing source keys, \code{source_value} and \code{n}. \code{source_value} is \code{NA} for the optional PostgreSQL \code{NULL} count row.
 }
 \description{
-Return value counts only for active dictionary rows explicitly marked with \code{profile_catalogue = TRUE}. Direct identifiers, quasi-identifiers, unclassified fields and columns exceeding \code{max_levels} are rejected before value counts are returned.
+Return value counts only for active dictionary rows explicitly marked with \code{profile_catalogue = TRUE}. Direct identifiers, quasi-identifiers, unclassified fields and columns exceeding \code{max_levels} are rejected before value counts are returned. The distinct-level limit counts non-missing values; a profiled column containing PostgreSQL \code{NULL} also returns one \code{source_value = NA} row with its count.
 }

--- a/man/epi_plot_list.Rd
+++ b/man/epi_plot_list.Rd
@@ -22,5 +22,5 @@ See example in \code{\link{epi_plot_cow_save}} and ggplot2 wrappers epi_plot_*()
 \code{\link{epi_plots_to_grid}}, \code{\link{epi_plot_cow_save}}.
 }
 \author{
-Antonio Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
+Antonio Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
 }

--- a/man/epi_plot_theme_1.Rd
+++ b/man/epi_plot_theme_1.Rd
@@ -47,5 +47,5 @@ Some colour codes:
 \href{https://ggplot2.tidyverse.org/reference/scale_colour_discrete.html}{ggplot2 colour scales}
 }
 \author{
-Antonio Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
+Antonio Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
 }

--- a/man/epi_stats_count_outliers.Rd
+++ b/man/epi_stats_count_outliers.Rd
@@ -46,5 +46,5 @@ summary(df$x)
 \code{\link[grDevices]{boxplot.stats}}
 }
 \author{
-Antonio J Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
+Antonio J Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
 }

--- a/man/epi_stats_format.Rd
+++ b/man/epi_stats_format.Rd
@@ -2,167 +2,62 @@
 % Please edit documentation in R/epi_stats_format.R
 \name{epi_stats_format}
 \alias{epi_stats_format}
-\title{Format a dataframe with numerical or integer columns}
+\title{Format numeric columns for display}
 \usage{
 epi_stats_format(df = NULL, skip = NULL, digits = 2, ...)
 }
 \arguments{
-\item{df}{Data.frame with summary to clean up.}
+\item{df}{Data frame containing columns to format.}
 
-\item{skip}{Columns to skip, pass as a string. Default is NULL.}
+\item{skip}{Optional numeric column positions to leave unchanged.}
 
-\item{digits}{Number of digits to print. Default is 2.}
+\item{digits}{Number of decimal places to display.}
 
-\item{...}{Any other parameter that can be passed to round().}
+\item{...}{Additional arguments passed to \code{\link[=format]{format()}}.}
 }
 \value{
-A data.frame with formatted and rounded values.
+A data frame in which formatted numeric columns are character vectors.
 }
 \description{
-epi_stats_format() formats columns so that digits appear even if they are x.00. Useful for saving a table with descriptive statistics. A data frame with an id column is expected. Check if column is numeric or integer, other types are not formatted. Pass a vector of column number to skip if needed. Values are rounded to the option passed to 'digits' digits = 2 by default
+Round and format numeric or integer columns with a fixed minimum number of decimal places. Formatting converts changed columns to character, so use the returned data frame for display rather than further calculation.
 }
 \examples{
-#####
-# Load libraries needed:
-library(episcout)
-library(dplyr)
-library(purrr)
-library(e1071)
-library(tibble)
-library(tidyr)
-#####
+# Shared examples for the three summary-table helpers.
 
-#####
-# Generate a data frame:
-n <- 1000
-df <- data.frame(
-  var_id = rep(1:(n / 2), each = 2),
-  var_to_rep = rep(c("Pre", "Post"), n / 2),
-  x = rnorm(n),
-  y = rbinom(n, 1, 0.50),
-  z = rpois(n, 2)
+set.seed(20260805)
+example_data <- data.frame(
+  visit = rep(c("baseline", "follow_up"), 4),
+  group = rep(c("A", "B"), each = 4),
+  score = c(10, 12, 14, 13, 9, 11, 15, 16),
+  outcome = factor(c(0, 0, 1, 0, 0, 1, 1, 1))
 )
 
-# Explore first and last rows for first columns:
-epi_head_and_tail(df)
-
-# Add character/factor columns:
-col_chr <- data.frame(
-  "chr1" = rep(c("A", "B"), length.out = 1000),
-  "chr2" = rep(c("C", "D"), length.out = 1000)
-)
-dim(col_chr)
-df_cont_chr <- tibble::as.tibble(cbind(df, col_chr))
-epi_head_and_tail(df_cont_chr)
-epi_head_and_tail(df_cont_chr, last_cols = TRUE)
-
-# Check variable types are what you expect:
-epi_clean_count_classes(df_cont_chr)
-str(df_cont_chr)
-dim(df_cont_chr)
-# var_id, y and z can be treated as factors or characters.
-summary(as.factor(df_cont_chr$y))
-summary(as.factor(df_cont_chr$z))
-# Here we'll only transform y though:
-df_cont_chr$y <- as.factor(df_cont_chr$y)
-epi_clean_count_classes(df_cont_chr)
-str(df_cont_chr)
-
-# Designate some values as codes to be counted separately:
-codes <- c("Pre", "A", "C", "1", "3")
-#####
-
-#####
-# Count when codes are present, pass these as character or factor, specify
-#  action is to count codes only:
-stat_sum1 <- epi_stats_summary(
-  df = df_cont_chr,
-  codes = codes,
-  class_type = "chr_fct",
-  action = "codes_only"
-)
-class(stat_sum1)
-stat_sum1
-#####
-
-#####
-# Add total for percentage calculation and order column to tidy up results:
-perc_n <- nrow(df_cont_chr)
-order_by <- "percent"
-stat_sum_tidy <- epi_stats_tidy(
-  sum_df = stat_sum1,
-  order_by = order_by,
-  perc_n = perc_n
-)
-stat_sum_tidy
-# Format them if needed:
-epi_stats_format(stat_sum_tidy, digits = 0)
-epi_stats_format(stat_sum_tidy, digits = 2)
-#####
-
-#####
-# Count integer or numeric codes:
-stat_sum2 <- epi_stats_summary(df_cont_chr,
-  codes = codes,
-  class_type = "int_num",
-  action = "codes_only"
-)
-stat_sum2
-# Tidy and format them:
-stat_sum_tidy <- epi_stats_tidy(
-  sum_df = stat_sum2,
-  order_by = order_by,
-  perc_n = perc_n
-)
-stat_sum_tidy
-epi_stats_format(stat_sum_tidy, digits = 0)
-epi_stats_format(stat_sum_tidy, digits = 2, skip = c(2, 3))
-#####
-
-#####
-# Get summary stats excluding contingency codes for character and factor columns:
-stat_sum3 <- epi_stats_summary(df_cont_chr,
-  codes = codes,
+# Summarise the character and factor columns after excluding a reviewed code.
+categorical_summary <- epi_stats_summary(
+  example_data,
+  codes = "follow_up",
   class_type = "chr_fct",
   action = "exclude"
 )
-stat_sum3
-# Tidy and format:
-stat_sum_tidy <- epi_stats_tidy(
-  sum_df = stat_sum3,
-  order_by = order_by,
-  perc_n = perc_n
-)
-stat_sum_tidy
-epi_stats_format(stat_sum_tidy, digits = 0)
-epi_stats_format(stat_sum_tidy, digits = 1)
-#####
+categorical_summary
 
-#####
-# Get summary stats for numeric/integer columns
-# while excluding certain codes/values:
-stat_sum4 <- epi_stats_summary(
-  df = df_cont_chr,
-  codes = codes,
-  class_type = "int_num",
-  action = "exclude"
-)
-class(stat_sum4)
-stat_sum4
-# Numeric data summary doesn't need tidying but could be formatted:
-epi_stats_format(stat_sum4, digits = 2)
-#####
-
-#####
-# If there are no codes to return the result is an empty data.frame (tibble):
-codes <- c("Per", "X", "55")
-stat_sum_zero <- epi_stats_summary(df_cont_chr,
-  codes = codes,
+# Convert counts to a display table; retain unformatted values for calculations.
+code_counts <- epi_stats_summary(
+  example_data,
+  codes = c("baseline", "A", "0"),
   class_type = "chr_fct",
   action = "codes_only"
 )
-stat_sum_zero
-#####
+tidy_counts <- epi_stats_tidy(
+  code_counts,
+  perc_n = nrow(example_data)
+)
+epi_stats_format(tidy_counts, digits = 1)
+
+# The typed contract profiles every supported column with explicit coverage.
+typed_summary <- epi_stats_summary(example_data, output = "typed")
+names(typed_summary)
+typed_summary$variables
 }
 \seealso{
 \code{\link{epi_stats_summary}}, \code{\link{epi_stats_tidy}}, \code{\link{epi_clean_cond_numeric}}, \code{\link[base]{format}}, \code{\link[base]{round}}.

--- a/man/epi_stats_summary.Rd
+++ b/man/epi_stats_summary.Rd
@@ -15,11 +15,11 @@ epi_stats_summary(
 \arguments{
 \item{df}{Data frame}
 
-\item{codes}{Specify codes to summarise or exclude as string. Default is NULL.}
+\item{codes}{Character vector of values to count or exclude. With typed output, these values are treated as global sentinel-missing codes.}
 
-\item{class_type}{Class of variables to summarise, 'chr_fct' or 'int_num'. Default is character and factor.}
+\item{class_type}{Current-output variable class: \code{"chr_fct"} or \code{"int_num"}. Leave the default when requesting typed output.}
 
-\item{action}{Values to summarise, 'codes_only' or 'exclude'. Default is 'exclude'.}
+\item{action}{Current-output handling of \code{codes}: \code{"codes_only"} or \code{"exclude"}. Typed output requires \code{"exclude"}.}
 
 \item{output}{Output contract. \code{"current"} preserves the existing class/action-specific tibble. \code{"typed"} returns complete typed summary components for every supported column and treats \code{codes} as global sentinel-missing values.}
 }
@@ -27,157 +27,52 @@ epi_stats_summary(
 With \code{output = "current"}, a tibble using the historical mode-specific schema. With \code{output = "typed"}, a list containing \code{variables}, \code{numeric}, \code{categorical}, \code{text}, \code{temporal} and \code{skipped} data frames.
 }
 \description{
-epi_stats_summary() provides summary descriptive statistics for columns belonging to either character and factor (class_type = 'chr_fct') or integer and numeric (class_type = 'int_num') while discarding values provided (codes). This is useful if data frame has contingency codes. Columns are ordered according to order in contingency codes option. Rows are then ordered in decreasing order according to column provided.
+Summarise character/factor or integer/numeric columns while counting or excluding reviewed code values. Set \code{output = "typed"} to return the canonical six-component descriptive contract for every supported column.
 }
 \note{
-Desgined with data frames that require pre-processing and likely have contingency and database codes. Action 'exclude' excludes the string values provided from the summary. Useful to quickly assess what a data.frame contains, types of values in each column and summary statistics if excluding codes.
+The current output is a historical convenience interface for data frames containing contingency or database codes. Prefer typed output for complete variable coverage and explicit missingness semantics.
 }
 \examples{
-#####
-# Load libraries needed:
-library(episcout)
-library(dplyr)
-library(purrr)
-library(e1071)
-library(tibble)
-library(tidyr)
-#####
+# Shared examples for the three summary-table helpers.
 
-#####
-# Generate a data frame:
-n <- 1000
-df <- data.frame(
-  var_id = rep(1:(n / 2), each = 2),
-  var_to_rep = rep(c("Pre", "Post"), n / 2),
-  x = rnorm(n),
-  y = rbinom(n, 1, 0.50),
-  z = rpois(n, 2)
+set.seed(20260805)
+example_data <- data.frame(
+  visit = rep(c("baseline", "follow_up"), 4),
+  group = rep(c("A", "B"), each = 4),
+  score = c(10, 12, 14, 13, 9, 11, 15, 16),
+  outcome = factor(c(0, 0, 1, 0, 0, 1, 1, 1))
 )
 
-# Explore first and last rows for first columns:
-epi_head_and_tail(df)
-
-# Add character/factor columns:
-col_chr <- data.frame(
-  "chr1" = rep(c("A", "B"), length.out = 1000),
-  "chr2" = rep(c("C", "D"), length.out = 1000)
-)
-dim(col_chr)
-df_cont_chr <- tibble::as.tibble(cbind(df, col_chr))
-epi_head_and_tail(df_cont_chr)
-epi_head_and_tail(df_cont_chr, last_cols = TRUE)
-
-# Check variable types are what you expect:
-epi_clean_count_classes(df_cont_chr)
-str(df_cont_chr)
-dim(df_cont_chr)
-# var_id, y and z can be treated as factors or characters.
-summary(as.factor(df_cont_chr$y))
-summary(as.factor(df_cont_chr$z))
-# Here we'll only transform y though:
-df_cont_chr$y <- as.factor(df_cont_chr$y)
-epi_clean_count_classes(df_cont_chr)
-str(df_cont_chr)
-
-# Designate some values as codes to be counted separately:
-codes <- c("Pre", "A", "C", "1", "3")
-#####
-
-#####
-# Count when codes are present, pass these as character or factor, specify
-#  action is to count codes only:
-stat_sum1 <- epi_stats_summary(
-  df = df_cont_chr,
-  codes = codes,
-  class_type = "chr_fct",
-  action = "codes_only"
-)
-class(stat_sum1)
-stat_sum1
-#####
-
-#####
-# Add total for percentage calculation and order column to tidy up results:
-perc_n <- nrow(df_cont_chr)
-order_by <- "percent"
-stat_sum_tidy <- epi_stats_tidy(
-  sum_df = stat_sum1,
-  order_by = order_by,
-  perc_n = perc_n
-)
-stat_sum_tidy
-# Format them if needed:
-epi_stats_format(stat_sum_tidy, digits = 0)
-epi_stats_format(stat_sum_tidy, digits = 2)
-#####
-
-#####
-# Count integer or numeric codes:
-stat_sum2 <- epi_stats_summary(df_cont_chr,
-  codes = codes,
-  class_type = "int_num",
-  action = "codes_only"
-)
-stat_sum2
-# Tidy and format them:
-stat_sum_tidy <- epi_stats_tidy(
-  sum_df = stat_sum2,
-  order_by = order_by,
-  perc_n = perc_n
-)
-stat_sum_tidy
-epi_stats_format(stat_sum_tidy, digits = 0)
-epi_stats_format(stat_sum_tidy, digits = 2, skip = c(2, 3))
-#####
-
-#####
-# Get summary stats excluding contingency codes for character and factor columns:
-stat_sum3 <- epi_stats_summary(df_cont_chr,
-  codes = codes,
+# Summarise the character and factor columns after excluding a reviewed code.
+categorical_summary <- epi_stats_summary(
+  example_data,
+  codes = "follow_up",
   class_type = "chr_fct",
   action = "exclude"
 )
-stat_sum3
-# Tidy and format:
-stat_sum_tidy <- epi_stats_tidy(
-  sum_df = stat_sum3,
-  order_by = order_by,
-  perc_n = perc_n
-)
-stat_sum_tidy
-epi_stats_format(stat_sum_tidy, digits = 0)
-epi_stats_format(stat_sum_tidy, digits = 1)
-#####
+categorical_summary
 
-#####
-# Get summary stats for numeric/integer columns
-# while excluding certain codes/values:
-stat_sum4 <- epi_stats_summary(
-  df = df_cont_chr,
-  codes = codes,
-  class_type = "int_num",
-  action = "exclude"
-)
-class(stat_sum4)
-stat_sum4
-# Numeric data summary doesn't need tidying but could be formatted:
-epi_stats_format(stat_sum4, digits = 2)
-#####
-
-#####
-# If there are no codes to return the result is an empty data.frame (tibble):
-codes <- c("Per", "X", "55")
-stat_sum_zero <- epi_stats_summary(df_cont_chr,
-  codes = codes,
+# Convert counts to a display table; retain unformatted values for calculations.
+code_counts <- epi_stats_summary(
+  example_data,
+  codes = c("baseline", "A", "0"),
   class_type = "chr_fct",
   action = "codes_only"
 )
-stat_sum_zero
-#####
+tidy_counts <- epi_stats_tidy(
+  code_counts,
+  perc_n = nrow(example_data)
+)
+epi_stats_format(tidy_counts, digits = 1)
+
+# The typed contract profiles every supported column with explicit coverage.
+typed_summary <- epi_stats_summary(example_data, output = "typed")
+names(typed_summary)
+typed_summary$variables
 }
 \seealso{
 \code{\link{epi_stats_numeric}}, \code{\link{epi_stats_format}}, \code{\link{epi_stats_tidy}}, \code{\link{epi_clean_cond_chr_fct}}, \code{\link{epi_clean_cond_numeric}}.
 }
 \author{
-Antonio J Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
+Antonio J Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
 }

--- a/man/epi_stats_tidy.Rd
+++ b/man/epi_stats_tidy.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/epi_stats_tidy.R
 \name{epi_stats_tidy}
 \alias{epi_stats_tidy}
-\title{Tidy up a data.frame with summary values}
+\title{Tidy a count summary}
 \usage{
 epi_stats_tidy(
   sum_df = NULL,
@@ -13,167 +13,62 @@ epi_stats_tidy(
 )
 }
 \arguments{
-\item{sum_df}{Data.frame with summary to clean up.}
+\item{sum_df}{Historical count summary returned by \code{\link[=epi_stats_summary]{epi_stats_summary()}}.}
 
-\item{order_by}{Column to order results by. Default is 'percent'.}
+\item{order_by}{Column used to order results. Default is \code{"percent"}.}
 
-\item{perc_n}{Number of rows from original dataframe to calculate percentage. Must be passed manually.}
+\item{perc_n}{Explicit denominator used to calculate percentages.}
 
-\item{digits}{= 2,}
+\item{digits}{Retained historical argument; the current implementation does not format or round values. Use \code{\link[=epi_stats_format]{epi_stats_format()}} for display formatting.}
 
-\item{decreasing}{Sort values by decreasing order. Default is TRUE.}
+\item{decreasing}{Whether to sort \code{order_by} in decreasing order.}
 }
 \value{
-Returns a dataframe as a tibble with values ordered and spread. Adds row sums and percentage.
+A wide tibble with \code{row_sums} and \code{percent} columns, ordered by \code{order_by}.
 }
 \description{
-epi_stats_tidy() cleans up the output from epi_stats_summary() and epi_stats_numeric(). Values are rounded to digits (default is 2). format(x, nsmall = digits) is used to ensure xx.00 are printed. Ordering uses as.numeric(as.character(x)) as 'percent' or other numeric column is assumed to be the preferred option. 'decreasing' is passed to order.
+Convert the historical count output from \code{\link[=epi_stats_summary]{epi_stats_summary()}} to a wide table, add row totals and percentages, and order rows by a selected numeric column.
 }
 \note{
-Note that format() will likely change the class type.
+The first output column is treated as the row identifier when calculating row totals. \code{perc_n} must match the intended denominator; the function does not infer the analysis population.
 }
 \examples{
-#####
-# Load libraries needed:
-library(episcout)
-library(dplyr)
-library(purrr)
-library(e1071)
-library(tibble)
-library(tidyr)
-#####
+# Shared examples for the three summary-table helpers.
 
-#####
-# Generate a data frame:
-n <- 1000
-df <- data.frame(
-  var_id = rep(1:(n / 2), each = 2),
-  var_to_rep = rep(c("Pre", "Post"), n / 2),
-  x = rnorm(n),
-  y = rbinom(n, 1, 0.50),
-  z = rpois(n, 2)
+set.seed(20260805)
+example_data <- data.frame(
+  visit = rep(c("baseline", "follow_up"), 4),
+  group = rep(c("A", "B"), each = 4),
+  score = c(10, 12, 14, 13, 9, 11, 15, 16),
+  outcome = factor(c(0, 0, 1, 0, 0, 1, 1, 1))
 )
 
-# Explore first and last rows for first columns:
-epi_head_and_tail(df)
-
-# Add character/factor columns:
-col_chr <- data.frame(
-  "chr1" = rep(c("A", "B"), length.out = 1000),
-  "chr2" = rep(c("C", "D"), length.out = 1000)
-)
-dim(col_chr)
-df_cont_chr <- tibble::as.tibble(cbind(df, col_chr))
-epi_head_and_tail(df_cont_chr)
-epi_head_and_tail(df_cont_chr, last_cols = TRUE)
-
-# Check variable types are what you expect:
-epi_clean_count_classes(df_cont_chr)
-str(df_cont_chr)
-dim(df_cont_chr)
-# var_id, y and z can be treated as factors or characters.
-summary(as.factor(df_cont_chr$y))
-summary(as.factor(df_cont_chr$z))
-# Here we'll only transform y though:
-df_cont_chr$y <- as.factor(df_cont_chr$y)
-epi_clean_count_classes(df_cont_chr)
-str(df_cont_chr)
-
-# Designate some values as codes to be counted separately:
-codes <- c("Pre", "A", "C", "1", "3")
-#####
-
-#####
-# Count when codes are present, pass these as character or factor, specify
-#  action is to count codes only:
-stat_sum1 <- epi_stats_summary(
-  df = df_cont_chr,
-  codes = codes,
-  class_type = "chr_fct",
-  action = "codes_only"
-)
-class(stat_sum1)
-stat_sum1
-#####
-
-#####
-# Add total for percentage calculation and order column to tidy up results:
-perc_n <- nrow(df_cont_chr)
-order_by <- "percent"
-stat_sum_tidy <- epi_stats_tidy(
-  sum_df = stat_sum1,
-  order_by = order_by,
-  perc_n = perc_n
-)
-stat_sum_tidy
-# Format them if needed:
-epi_stats_format(stat_sum_tidy, digits = 0)
-epi_stats_format(stat_sum_tidy, digits = 2)
-#####
-
-#####
-# Count integer or numeric codes:
-stat_sum2 <- epi_stats_summary(df_cont_chr,
-  codes = codes,
-  class_type = "int_num",
-  action = "codes_only"
-)
-stat_sum2
-# Tidy and format them:
-stat_sum_tidy <- epi_stats_tidy(
-  sum_df = stat_sum2,
-  order_by = order_by,
-  perc_n = perc_n
-)
-stat_sum_tidy
-epi_stats_format(stat_sum_tidy, digits = 0)
-epi_stats_format(stat_sum_tidy, digits = 2, skip = c(2, 3))
-#####
-
-#####
-# Get summary stats excluding contingency codes for character and factor columns:
-stat_sum3 <- epi_stats_summary(df_cont_chr,
-  codes = codes,
+# Summarise the character and factor columns after excluding a reviewed code.
+categorical_summary <- epi_stats_summary(
+  example_data,
+  codes = "follow_up",
   class_type = "chr_fct",
   action = "exclude"
 )
-stat_sum3
-# Tidy and format:
-stat_sum_tidy <- epi_stats_tidy(
-  sum_df = stat_sum3,
-  order_by = order_by,
-  perc_n = perc_n
-)
-stat_sum_tidy
-epi_stats_format(stat_sum_tidy, digits = 0)
-epi_stats_format(stat_sum_tidy, digits = 1)
-#####
+categorical_summary
 
-#####
-# Get summary stats for numeric/integer columns
-# while excluding certain codes/values:
-stat_sum4 <- epi_stats_summary(
-  df = df_cont_chr,
-  codes = codes,
-  class_type = "int_num",
-  action = "exclude"
-)
-class(stat_sum4)
-stat_sum4
-# Numeric data summary doesn't need tidying but could be formatted:
-epi_stats_format(stat_sum4, digits = 2)
-#####
-
-#####
-# If there are no codes to return the result is an empty data.frame (tibble):
-codes <- c("Per", "X", "55")
-stat_sum_zero <- epi_stats_summary(df_cont_chr,
-  codes = codes,
+# Convert counts to a display table; retain unformatted values for calculations.
+code_counts <- epi_stats_summary(
+  example_data,
+  codes = c("baseline", "A", "0"),
   class_type = "chr_fct",
   action = "codes_only"
 )
-stat_sum_zero
-#####
+tidy_counts <- epi_stats_tidy(
+  code_counts,
+  perc_n = nrow(example_data)
+)
+epi_stats_format(tidy_counts, digits = 1)
+
+# The typed contract profiles every supported column with explicit coverage.
+typed_summary <- epi_stats_summary(example_data, output = "typed")
+names(typed_summary)
+typed_summary$variables
 }
 \seealso{
 \code{\link{epi_stats_summary}}, \code{\link{epi_stats_format}}, \code{\link{epi_stats_numeric}}.

--- a/man/epi_write.Rd
+++ b/man/epi_write.Rd
@@ -51,5 +51,5 @@ epi_write(some_dataframe, "some_dataframe.tsv")
 \code{\link[data.table]{fwrite}}
 }
 \author{
-Antonio Berlanga-Taylor <\url{https://github.com/AntonioJBT/episcout}>
+Antonio Berlanga-Taylor \if{html}{\out{<\url{https://github.com/AntonioJBT/episcout}>}}
 }

--- a/man/epi_write_df.Rd
+++ b/man/epi_write_df.Rd
@@ -13,20 +13,20 @@ epi_write_df(df, results_subdir, file_n, suffix)
 
 \item{file_n}{A character string specifying the base name of the file (without the suffix).}
 
-\item{suffix}{A character string specifying the file extension (e.g., "txt", "csv").}
+\item{suffix}{A character string specifying the filename extension. Use \code{"tsv"} for the default tab-separated output.}
 }
 \value{
 The full file path of the saved file. Prints a message indicating the file's location.
 }
 \description{
-This function constructs a file path using a specified subdirectory, file name, and suffix, then writes a data frame to that file. It is designed for flexibility in saving results with standardized naming conventions.
+This function constructs a file path using a specified subdirectory, file name and suffix, then calls \code{\link[=epi_write]{epi_write()}}. The suffix changes only the filename; output remains tab-separated unless \code{epi_write()} is called directly with another \code{sep} value.
 }
 \examples{
 \dontrun{
 # Example usage
 results_subdir <- "output"
 file_n <- "desc_dates"
-suffix <- "txt"
+suffix <- "tsv"
 epi_write_df(sum_dates_df, results_subdir, file_n, suffix)
 }
 

--- a/man/episcout-package.Rd
+++ b/man/episcout-package.Rd
@@ -9,7 +9,7 @@
 Helpers for cleaning, exploring and visualising data, including specification-first EDA and an audit-first PostgreSQL workflow for stable longitudinal pseudonymisation.
 }
 \details{
-Start with \code{vignette("introduction_episcout")} for package helpers, \code{vignette("specification-first-eda")} for reviewed EDA, or \code{vignette("longitudinal-pseudonymisation")} for one stable pseudonymous identity across related PostgreSQL tables. The longitudinal guide covers database prerequisites, value-free linkage metadata, read-only audits, blockers, apply, recovery and EDA handoff.
+Start with \code{vignette("introduction_episcout")} for package helpers, \code{vignette("specification-first-eda")} for reviewed EDA, or \code{vignette("longitudinal-pseudonymisation")} for one stable pseudonymous identity across related PostgreSQL tables. The longitudinal guide covers database prerequisites, value-free linkage metadata, read-only audits, blockers, apply, recovery and EDA handoff. The installed \code{examples/db-to-report/walkthrough.R} script provides a complete interactive synthetic exercise from duplicate review and database setup through pseudonymisation, EDA, Table 1 and HTML report output.
 
 Pseudonymised data remain restricted personal data. They are not anonymous or automatically disclosure-controlled.
 }

--- a/vignettes/introduction_episcout.Rmd
+++ b/vignettes/introduction_episcout.Rmd
@@ -55,7 +55,7 @@ install.packages(c(
 
 Many parameters are given as defaults, admittedly with quite a bit of personal preference, but with the aim of processing hundreds of thousands of observations from hundreds of variables from multiple data sets a bit faster. Hence, convenience and standardisation are often preferred. This may not be your case however but it is simple enough to defer to your preferred R packages.
 
-Below are a number of examples of how to use lower-level episcout helper functions. For a complete specification-first EDA workflow, see the `specification-first-eda` vignette. For stable pseudonyms across related PostgreSQL tables, see the friendly, audit-first `longitudinal-pseudonymisation` vignette before handling restricted data.
+Below are a number of examples of how to use lower-level episcout helper functions. For a complete specification-first EDA workflow, see the `specification-first-eda` vignette. For stable pseudonyms across related PostgreSQL tables, see the friendly, audit-first `longitudinal-pseudonymisation` vignette before handling restricted data. To practise the complete journey with a neutral CSV and disposable PostgreSQL database, open the installed `examples/db-to-report/walkthrough.R` script.
 
 ```{r library, message=FALSE}
 library(episcout)

--- a/vignettes/longitudinal-pseudonymisation.Rmd
+++ b/vignettes/longitudinal-pseudonymisation.Rmd
@@ -20,6 +20,8 @@ knitr::opts_chunk$set(
 
 > **Privacy boundary:** Pseudonymised data remain restricted personal data. They are not anonymous, automatically disclosure-controlled or automatically safe to share. Keep the identity registry and output behind reviewed access controls.
 
+This vignette is the detailed governance and recovery guide. For a runnable learning example using a neutral longitudinal CSV and uniquely named disposable schemas, open the installed `examples/db-to-report/walkthrough.R` script and run it section by section.
+
 ## 1. What this workflow does and when to use it
 
 Use this workflow when related PostgreSQL tables each have one declared entity-ID column and must use the same stable pseudonymous token over time. A reviewed dictionary decides which columns may enter output, a value-free linkage specification declares exact identity semantics, and a restricted registry preserves token stability across runs.

--- a/vignettes/specification-first-eda.Rmd
+++ b/vignettes/specification-first-eda.Rmd
@@ -24,7 +24,9 @@ cat("This vignette needs ggplot2 to run the plotting step. Install ggplot2 to ru
 
 Specification-first EDA starts with a data dictionary rather than with ad hoc analysis code. The same specification can be used while data access is pending, then reused with real data once they arrive.
 
-The MVP workflow is designed to:
+For an executable end-to-end example that also covers duplicate review, longitudinal PostgreSQL pseudonymisation and the handoff into this workflow, open the installed `examples/db-to-report/walkthrough.R` script and run it section by section.
+
+The specification-first workflow is designed to:
 
 - validate expected variables;
 - generate simple synthetic data for pipeline preparation;


### PR DESCRIPTION
## Summary

- audit and align the README, package help, project template and all four vignettes with the PostgreSQL EDA and longitudinal pseudonymisation interfaces from #193
- add an installed, section-by-section R walkthrough from a deliberately duplicated synthetic longitudinal CSV through PostgreSQL inventory, dictionary review, stable pseudonymisation, aggregate EDA, plots, Table 1 and an HTML report
- add the neutral CSV fixture, PostgreSQL setup/cleanup guidance and repaired tracked examples for the summary helpers
- clarify current catalogue NULL and `epi_write_df()` delimiter behaviour without changing implementation

## Dependency

#193 is merged. This PR now contains one documentation-only commit against its merged implementation.

## Documentation review

The review covered 100 generated help topics, all four vignettes, the README, package-level help, NEWS, PROJECT_MAP and the installed project/report guidance. No SDD or TDD was added because this PR changes no API, behaviour or architecture.

## Verification

- complete installed walkthrough run against a disposable PostgreSQL 17.10 database
  - 11 CSV rows; one reviewed exact duplicate removed
  - 5 participants and 10 longitudinal visits loaded
  - audit/apply pseudonymisation completed with 5 stable entities
  - aggregate PostgreSQL EDA bundle, 9 SVG plots, 60-row Table 1 and HTML report produced
  - disposable schemas removed through the documented cleanup path
- all four vignettes rendered from the installed package
- repaired shared examples executed
- all generated Rd passed `tools::checkRd()`; code/documentation consistency passed
- all 18 external documentation URLs passed `urlchecker::url_check()`
- `scripts/check-local.sh`: no lints, tests pass
- final `devtools::check(manual = FALSE)`: 0 errors, 0 warnings; one environment-only NOTE because current time could not be verified
- GitHub CI: all 7 checks pass, including PostgreSQL integration, Ubuntu, macOS, coverage, Codecov and CodeFactor

## Follow-up issues

- #195 — duplicate PostgreSQL advisory-lock releases emit warnings after successful pseudonymisation
- #196 — render an HTML report directly from an aggregate PostgreSQL EDA bundle
- #197 — catalogue profiling can return a NULL row beyond `max_levels`
- #198 — `epi_write_df()` can create tab-delimited output with a `.csv` suffix

The walkthrough remains successful despite the warnings tracked in #195.